### PR TITLE
changing arguments from dictionary to ordereddict

### DIFF
--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -6,7 +6,7 @@ import argparse
 from operator import add
 import inspect
 import marshmallow as mm
-
+import collections
 FIELD_TYPE_MAP = {v: k for k, v in mm.Schema.TYPE_MAPPING.items()}
 
 
@@ -87,7 +87,7 @@ def smart_merge(a, b, path=None, merge_keys=None, overwrite_with_none=False):
 def build_schema_arguments(schema, arguments=None, path=None):
     """given a jsonschema, create a dictionary of argparse arguments"""
     path = [] if path is None else path
-    arguments = {} if arguments is None else arguments
+    arguments = collections.OrderedDict() if arguments is None else arguments
 
     for field_name, field in schema.declared_fields.items():
         if isinstance(field, mm.fields.Nested):


### PR DESCRIPTION
I am proposing here that we change to using an ordereddict for building the argparse parser, so that as we go through the schema tree the order that we add the arguments is preserved when we construct the Parser.  This will make the help statements print out in the correct order, rather than the random order they were before.... I think.  Wanted someone to check my thinking.