### PR TITLE
Bugfix: defaults implemented as an overriden schema

### DIFF
--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -26,7 +26,7 @@ class ArgSchemaParser(object):
                  input_data=None,  # dictionary input as option instead of --input_json
                  schema_type=schemas.ArgSchema,  # schema for parsing arguments
                  args=None,
-                 logger_name=__name__):
+                 logger_name=__name__, **kwargs):
 
         schema = schema_type()
 
@@ -48,7 +48,7 @@ class ArgSchemaParser(object):
         args = utils.smart_merge(jsonargs, argsdict)
 
         # validate with load!
-        result = self.load_schema_with_defaults(schema, args)
+        result = self.load_schema_with_defaults(schema, args, **kwargs)
         if len(result.errors) > 0:
             raise mm.ValidationError(json.dumps(result.errors, indent=2))
 
@@ -59,7 +59,7 @@ class ArgSchemaParser(object):
             logger_name, self.args.get('log_level'))
 
     @staticmethod
-    def load_schema_with_defaults(schema, args, safedefaults=True):
+    def load_schema_with_defaults(schema, args, safedefaults=True, **kwargs):
         """load_schema_with_defaults(schema, args)
         function for deserializing the arguments dictionary (args)
         given the schema (schema) making sure that the default values have
@@ -73,7 +73,7 @@ class ArgSchemaParser(object):
                 through marshmallow
         """
         if (not isinstance(schema, schemas.DefaultSchema) and
-                safedefaults==False):
+                not safedefaults):
             defaults = []
 
             # find all of the schema entries with default values

--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -48,7 +48,7 @@ class ArgSchemaParser(object):
         args = utils.smart_merge(jsonargs, argsdict)
 
         # validate with load!
-        result = self.load_schema_with_defaults(schema, args)
+        result = schema.load(args)
         if len(result.errors) > 0:
             raise mm.ValidationError(json.dumps(result.errors, indent=2))
 
@@ -57,48 +57,6 @@ class ArgSchemaParser(object):
 
         self.logger = self.initialize_logger(
             logger_name, self.args.get('log_level'))
-
-    @staticmethod
-    def load_schema_with_defaults(schema, args, safedefaults=True):
-        """load_schema_with_defaults(schema, args)
-        function for deserializing the arguments dictionary (args)
-        given the schema (schema) making sure that the default values have
-        been filled in.
-        inputs)
-            args: a dictionary of input arguments
-            schema: a marshmallow.Schema schema specifiying the schema the
-                input should fit
-        outputs)
-            a deserialized dictionary of the parameters converted
-                through marshmallow
-        """
-        if (not isinstance(schema, schemas.DefaultSchema) and
-                safedefaults==False):
-            defaults = []
-
-            # find all of the schema entries with default values
-            schemata = [(schema, [])]
-            while schemata:
-                subschema, path = schemata.pop()
-                for k, v in subschema.declared_fields.items():
-                    if isinstance(v, mm.fields.Nested):
-                        schemata.append((v.schema, path + [k]))
-                    elif v.default != mm.missing:
-                        defaults.append((path + [k], v.default))
-
-            # put the default entries into the args dictionary
-            args = copy.deepcopy(args)
-            for path, val in defaults:
-                d = args
-                for path_item in path[:-1]:
-                    d = d.setdefault(path_item, {})
-                if path[-1] not in d:
-                    d[path[-1]] = val
-
-        # load the dictionary via the schema
-        result = schema.load(args)
-
-        return result
 
     @staticmethod
     def initialize_logger(name, log_level):

--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -3,14 +3,14 @@ subclassed when using this library
 '''
 import json
 import logging
-from . import schemas
 import copy
+from . import schemas
 from . import utils
 import marshmallow as mm
 
 
 class ArgSchemaParser(object):
-    '''ArgSchemaParser(input_data=None, schema_type = schemas.ArgSchema,
+    """ArgSchemaParser(input_data=None, schema_type = schemas.ArgSchema,
     args = None, logger_name = 'argschema')
     inputs)
         input data = None, dictionary parameters as option
@@ -20,7 +20,7 @@ class ArgSchemaParser(object):
             [] if you want to bypass command line parsing
         logger_name = 'argschema', name of logger from the logging
             module you want to instantiate
-    '''
+    """
 
     def __init__(self,
                  input_data=None,  # dictionary input as option instead of --input_json
@@ -49,7 +49,6 @@ class ArgSchemaParser(object):
 
         # validate with load!
         result = self.load_schema_with_defaults(schema, args)
-
         if len(result.errors) > 0:
             raise mm.ValidationError(json.dumps(result.errors, indent=2))
 
@@ -60,8 +59,8 @@ class ArgSchemaParser(object):
             logger_name, self.args.get('log_level'))
 
     @staticmethod
-    def load_schema_with_defaults(schema, args):
-        '''load_schema_with_defaults(schema, args)
+    def load_schema_with_defaults(schema, args, safedefaults=True):
+        """load_schema_with_defaults(schema, args)
         function for deserializing the arguments dictionary (args)
         given the schema (schema) making sure that the default values have
         been filled in.
@@ -72,27 +71,29 @@ class ArgSchemaParser(object):
         outputs)
             a deserialized dictionary of the parameters converted
                 through marshmallow
-        '''
-        defaults = []
+        """
+        if (not isinstance(schema, schemas.DefaultSchema) and
+                safedefaults==False):
+            defaults = []
 
-        # find all of the schema entries with default values
-        schemas = [(schema, [])]
-        while schemas:
-            subschema, path = schemas.pop()
-            for k, v in subschema.declared_fields.items():
-                if isinstance(v, mm.fields.Nested):
-                    schemas.append((v.schema, path + [k]))
-                elif v.default != mm.missing:
-                    defaults.append((path + [k], v.default))
+            # find all of the schema entries with default values
+            schemata = [(schema, [])]
+            while schemata:
+                subschema, path = schemata.pop()
+                for k, v in subschema.declared_fields.items():
+                    if isinstance(v, mm.fields.Nested):
+                        schemata.append((v.schema, path + [k]))
+                    elif v.default != mm.missing:
+                        defaults.append((path + [k], v.default))
 
-        # put the default entries into the args dictionary
-        args = copy.deepcopy(args)
-        for path, val in defaults:
-            d = args
-            for path_item in path[:-1]:
-                d = d.setdefault(path_item, {})
-            if path[-1] not in d:
-                d[path[-1]] = val
+            # put the default entries into the args dictionary
+            args = copy.deepcopy(args)
+            for path, val in defaults:
+                d = args
+                for path_item in path[:-1]:
+                    d = d.setdefault(path_item, {})
+                if path[-1] not in d:
+                    d[path[-1]] = val
 
         # load the dictionary via the schema
         result = schema.load(args)
@@ -101,14 +102,14 @@ class ArgSchemaParser(object):
 
     @staticmethod
     def initialize_logger(name, log_level):
-        '''initializes the logger to a level with a name
+        """initializes the logger to a level with a name
         logger = initialize_logger(name, log_level)
         inputs)
             name) name of the logger
             log_level) log level of the logger
         outputs)
             logger: a logging.Logger set with the name and level specified
-        '''
+        """
         level = logging.getLevelName(log_level)
 
         logging.basicConfig()
@@ -117,9 +118,9 @@ class ArgSchemaParser(object):
         return logger
 
     def run(self):
-        '''standin run method to illustrate what the arguments are after
+        """standin run method to illustrate what the arguments are after
         validation and parsing should overwrite in your subclass
         run() prints the arguments using json.dumps
-        '''
+        """
         print("running! with args")
         print(json.dumps(self.args, indent=2))

--- a/argschema/schemas.py
+++ b/argschema/schemas.py
@@ -2,11 +2,25 @@ import marshmallow as mm
 from .fields import LogLevel, InputFile, OutputFile
 
 
-class ArgSchema(mm.Schema):
-    '''The base marshmallow schema used by ArgSchemaParser to identify input and
-    output json files
+class DefaultSchema(mm.Schema):
+    """Schema class with support for making fields default to
+    values defined by that field's arguments.
+    """
+
+    @mm.pre_load
+    def make_object(self, in_data):
+        for name, field in self.fields.items():
+            if name not in in_data:
+                in_data[name] = field.default
+        return in_data
+
+
+class ArgSchema(DefaultSchema):
+    """The base marshmallow schema used by ArgSchemaParser to identify
+    input and output json files
     and the log_level
-    '''
+    """
+
     input_json = InputFile(
         metadata={'description': "file path of input json file"})
     output_json = OutputFile(

--- a/argschema/schemas.py
+++ b/argschema/schemas.py
@@ -11,7 +11,8 @@ class DefaultSchema(mm.Schema):
     def make_object(self, in_data):
         for name, field in self.fields.items():
             if name not in in_data:
-                in_data[name] = field.default
+                if field.default is not None:
+                    in_data[name] = field.default
         return in_data
 
 

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -14,7 +14,7 @@ FIELD_TYPE_MAP = {v: k for k, v in mm.Schema.TYPE_MAPPING.items()}
 def args_to_dict(argsobj):
     d = {}
     argsdict = vars(argsobj)
-    for field, v in argsdict.iteritems():
+    for field, v in argsdict.items():
         if v is not None:
             parts = field.split('.')
             root = d

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -5,31 +5,33 @@ import logging
 import argparse
 from operator import add
 import inspect
-import marshmallow as mm
 import collections
+import marshmallow as mm
+
 FIELD_TYPE_MAP = {v: k for k, v in mm.Schema.TYPE_MAPPING.items()}
 
 
 def args_to_dict(argsobj):
     d = {}
     argsdict = vars(argsobj)
-    for field in argsdict.keys():
-        parts = field.split('.')
-        root = d
-        for i in range(len(parts)):
-            if i == (len(parts) - 1):
-                root[parts[i]] = argsdict.get(field)
-            else:
-                if parts[i] not in root.keys():
-                    root[parts[i]] = {}
-                root = root[parts[i]]
+    for field, v in argsdict.iteritems():
+        if v is not None:
+            parts = field.split('.')
+            root = d
+            for i in range(len(parts)):
+                if i == (len(parts) - 1):
+                    root[parts[i]] = v
+                else:
+                    if parts[i] not in root.keys():
+                        root[parts[i]] = {}
+                    root = root[parts[i]]
     return d
 
 
 def merge_value(a, b, key, func=add):
-    '''attempt to merge these keys using function defined by
+    """attempt to merge these keys using function defined by
     func (default to add) raise an exception if this fails
-    '''
+    """
     try:
         return func(a[key], b[key])
     except:
@@ -39,9 +41,9 @@ def merge_value(a, b, key, func=add):
 
 
 def do_join(a, b, key, merge_keys=None):
-    '''determine if we should/can attempt to merge a[key],b[key]
+    """determine if we should/can attempt to merge a[key],b[key]
     if merge_keys is not specified, then no
-    '''
+    """
     if merge_keys is None:
         return False
     # only consider if key is in merge_keys
@@ -138,8 +140,7 @@ def build_schema_arguments(schema, arguments=None, path=None):
 
 
 def schema_argparser(schema):
-    """ given a jsonschema, build an argparse.ArgumentParser """
-
+    """given a jsonschema, build an argparse.ArgumentParser"""
     arguments = build_schema_arguments(schema)
 
     parser = argparse.ArgumentParser()

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -78,7 +78,7 @@ SimpleExtension_example_valid = {
 @pytest.fixture(scope='module')
 def simple_extension_file(tmpdir_factory):
     file_ = tmpdir_factory.mktemp('test').join('testinput.json')
-    file_.write(json.dumps(SimpleExtension_example_valid))
+    file_.write(json.dumps(SimpleExtension_example_valid))    
     return file_
 
 
@@ -101,6 +101,7 @@ def test_simple_extension_pass():
 def test_simple_extension_write_pass(simple_extension_file):
     args = ['--input_json', str(simple_extension_file)]
     mod = ArgSchemaParser(schema_type=SimpleExtension, args=args)
+    print json.dumps(mod.args,indent=2)
     assert mod.args['test']['a'] == 'hello'
     assert mod.args['test']['b'] == 1
     assert len(mod.args['test']['d']) == 3

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -38,7 +38,7 @@ def test_log_catch():
 
 
 class MyExtension(mm.Schema):
-    a = mm.fields.Str(metadata={'description': 'a string'})
+    a = mm.fields.Str(metadata={'description': 'a string'},required=True)
     b = mm.fields.Int(metadata={'description': 'an integer'})
     c = mm.fields.Int(metadata={'description': 'an integer'}, default=10)
     d = mm.fields.List(mm.fields.Int,

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -50,6 +50,7 @@ class SimpleExtension(ArgSchema):
     test = mm.fields.Nested(MyExtension, default=None, required=True)
 
 
+
 def test_simple_extension_required():
     with pytest.raises(mm.ValidationError):
         example1 = {}
@@ -135,3 +136,24 @@ def test_bad_input_json_argparse():
     args = ['--input_json', 'not_a_file.json']
     with pytest.raises(mm.ValidationError):
         mod = ArgSchemaParser(schema_type=SimpleExtension, args=args)
+
+#TESTS DEMONSTRATING BAD BEHAVIOR OF DEFAULT LOADING
+class MyExtensionOld(mm.Schema):
+    a = mm.fields.Str(metadata={'description': 'a string'})
+    b = mm.fields.Int(metadata={'description': 'an integer'})
+    c = mm.fields.Int(metadata={'description': 'an integer'}, default=10)
+    d = mm.fields.List(mm.fields.Int,
+                       metadata={'description': 'a list of integers'})
+
+
+class SimpleExtensionOld(ArgSchema):
+    test = mm.fields.Nested(MyExtension, default=None, required=True)
+
+def test_simple_extension_old_pass():
+    mod = ArgSchemaParser(
+        input_data=SimpleExtension_example_valid,
+        schema_type=SimpleExtensionOld, args=[])
+    assert mod.args['test']['a'] == 'hello'
+    assert mod.args['test']['b'] == 1
+    assert mod.args['test']['c'] == 10
+    assert len(mod.args['test']['d']) == 3

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -147,7 +147,7 @@ class MyExtensionOld(mm.Schema):
 
 
 class SimpleExtensionOld(ArgSchema):
-    test = mm.fields.Nested(MyExtension, default=None, required=True)
+    test = mm.fields.Nested(MyExtensionOld, default=None, required=True)
 
 def test_simple_extension_old_pass():
     mod = ArgSchemaParser(
@@ -157,3 +157,4 @@ def test_simple_extension_old_pass():
     assert mod.args['test']['b'] == 1
     assert mod.args['test']['c'] == 10
     assert len(mod.args['test']['d']) == 3
+

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -96,6 +96,7 @@ def test_simple_extension_pass():
         schema_type=SimpleExtension, args=[])
     assert mod.args['test']['a'] == 'hello'
     assert mod.args['test']['b'] == 1
+    assert mod.args['test']['c'] == 10
     assert len(mod.args['test']['d']) == 3
 
 
@@ -106,6 +107,7 @@ def test_simple_extension_write_pass(simple_extension_file):
         args=args)
     assert mod.args['test']['a'] == 'hello'
     assert mod.args['test']['b'] == 1
+    assert mod.args['test']['c'] == 10
     assert len(mod.args['test']['d']) == 3
     assert mod.logger.getEffectiveLevel() == logging.ERROR
 

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -158,3 +158,46 @@ def test_simple_extension_old_pass():
     assert mod.args['test']['c'] == 10
     assert len(mod.args['test']['d']) == 3
 
+class RecursiveSchema(argschema.schemas.DefaultSchema):
+    children = mm.fields.Nested("self",many=True,
+                                metadata={'description': 'children of this node'})
+    name = mm.fields.Str(default = "anonymous",
+                           metadata={'description': 'name of this node'})
+
+class ExampleRecursiveSchema(ArgSchema):
+    tree = mm.fields.Nested(RecursiveSchema, required=True)
+
+recursive_data = {
+    'tree': {
+                'name':'root',
+                'children':[
+                    {
+                        "name":'child1'
+                    },
+                    {
+                        "name":"branch1",
+                        "children":[
+                            {
+                                "name":"subchild1"
+                            },
+                            {
+                            },
+                            {    
+                            }
+                        ]
+                    }
+                ]
+            }
+    }
+
+
+def test_recursive_schema():
+    mod = ArgSchemaParser(
+        input_data=recursive_data,
+        schema_type=ExampleRecursiveSchema, args=[])
+    assert mod.args['tree']['name'] == 'root'
+    assert len(mod.args['tree']['children']) == 2
+    assert mod.args['tree']['children'][0]['name'] == 'child1'
+    assert mod.args['tree']['children'][1]['name'] == 'branch1'
+    assert len(mod.args['tree']['children'][1]['children']) == 3 
+    assert mod.args['tree']['children'][1]['children'][2]['name']=='anonymous'


### PR DESCRIPTION
While going over a derivative module which required recursive nested fields with @fcollman we found a bug that caused an infinite loop in while calling `argschema.ArgSchemaParser.load_schema_with_defaults`.  It looks like overriding a method in the marshmallow schema to deal with defaults (and ignoring ArgSchemaParser static method) fixes this, but relying on our new `argschema.schemas.DefaultSchema` superclass would break backward-compatibility.

I've added an argument to `argschema.ArgSchemaParser.load_schema_with_defaults` which can optionally allow this unsafe behavior, but would be open to hearing any better ideas on how to deal with breaking argschema compatibility with the base `marshmallow.Schema` class.