### PR TITLE
Defaultschema

### DIFF
--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -96,6 +96,7 @@ class ArgSchemaParser(object):
         else:
             jsonargs = input_data if input_data else {}
 
+        self.logger = self.initialize_logger(logger_name,'WARNING')
         # merge the command line dictionary into the input json
         args = utils.smart_merge(jsonargs, argsdict)
 
@@ -110,10 +111,9 @@ class ArgSchemaParser(object):
         self.logger = self.initialize_logger(
             logger_name, self.args.get('log_level'))
 
-    @staticmethod
-    def load_schema_with_defaults(schema, args):
+    def load_schema_with_defaults(self  ,schema, args):
         """load_schema_with_defaults(schema, args)
-        function for deserializing the arguments dictionary (args)
+        method for deserializing the arguments dictionary (args)
         given the schema (schema) making sure that the default values have
         been filled in.
         inputs)
@@ -128,6 +128,11 @@ class ArgSchemaParser(object):
         is_non_default = contains_non_default_schemas(schema)
         if (not is_recursive) and is_non_default:
             # throw a warning
+            self.logger.warning("""DEPRECATED:You are using a Schema which contains 
+            a Schema which is not subclassed from argschema.DefaultSchema, 
+            default values will not work correctly in this case, 
+            this use is deprecated, and future versions will not fill in default 
+            values when you use non-DefaultSchema subclasses""")
             args = fill_defaults(schema, args)
         if is_recursive and is_non_default:
             raise mm.ValidationError(

--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -3,14 +3,66 @@ subclassed when using this library
 '''
 import json
 import logging
-from . import schemas
 import copy
+from . import schemas
 from . import utils
 import marshmallow as mm
 
 
+def contains_non_default_schemas(schema, schema_list=[]):
+    """returns true if this schema contains a schema which was not an instance of DefaultSchema"""
+    if not isinstance(schema, schemas.DefaultSchema):
+        return True
+    for k, v in schema.declared_fields.items():
+        if isinstance(v, mm.fields.Nested):
+            if type(v.schema) in schema_list:
+                return False
+            else:
+                schema_list.append(type(v.schema))
+                if contains_non_default_schemas(v.schema, schema_list):
+                    return True
+    return False
+
+
+def is_recursive_schema(schema, schema_list=[]):
+    """returns true if this schema contains recursive elements"""
+    for k, v in schema.declared_fields.items():
+        if isinstance(v, mm.fields.Nested):
+            if type(v.schema) in schema_list:
+                return True
+            else:
+                schema_list.append(type(v.schema))
+                if is_recursive_schema(v.schema, schema_list):
+                    return True
+    return False
+
+
+def fill_defaults(schema, args):
+    defaults = []
+
+    # find all of the schema entries with default values
+    schemata = [(schema, [])]
+    while schemata:
+        subschema, path = schemata.pop()
+        for k, v in subschema.declared_fields.items():
+            if isinstance(v, mm.fields.Nested):
+                schemata.append((v.schema, path + [k]))
+            elif v.default != mm.missing:
+                defaults.append((path + [k], v.default))
+
+    # put the default entries into the args dictionary
+    args = copy.deepcopy(args)
+    for path, val in defaults:
+        d = args
+        for path_item in path[:-1]:
+            d = d.setdefault(path_item, {})
+        if path[-1] not in d:
+            d[path[-1]] = val
+    return args
+
+
 class ArgSchemaParser(object):
-    '''ArgSchemaParser(input_data=None, schema_type = schemas.ArgSchema,
+    """ArgSchemaParser(input_data=None, schema_type = schemas.ArgSchema,
     args = None, logger_name = 'argschema')
     inputs)
         input data = None, dictionary parameters as option
@@ -20,7 +72,7 @@ class ArgSchemaParser(object):
             [] if you want to bypass command line parsing
         logger_name = 'argschema', name of logger from the logging
             module you want to instantiate
-    '''
+    """
 
     def __init__(self,
                  input_data=None,  # dictionary input as option instead of --input_json
@@ -49,7 +101,6 @@ class ArgSchemaParser(object):
 
         # validate with load!
         result = self.load_schema_with_defaults(schema, args)
-
         if len(result.errors) > 0:
             raise mm.ValidationError(json.dumps(result.errors, indent=2))
 
@@ -61,7 +112,7 @@ class ArgSchemaParser(object):
 
     @staticmethod
     def load_schema_with_defaults(schema, args):
-        '''load_schema_with_defaults(schema, args)
+        """load_schema_with_defaults(schema, args)
         function for deserializing the arguments dictionary (args)
         given the schema (schema) making sure that the default values have
         been filled in.
@@ -72,27 +123,15 @@ class ArgSchemaParser(object):
         outputs)
             a deserialized dictionary of the parameters converted
                 through marshmallow
-        '''
-        defaults = []
-
-        # find all of the schema entries with default values
-        schemas = [(schema, [])]
-        while schemas:
-            subschema, path = schemas.pop()
-            for k, v in subschema.declared_fields.items():
-                if isinstance(v, mm.fields.Nested):
-                    schemas.append((v.schema, path + [k]))
-                elif v.default != mm.missing:
-                    defaults.append((path + [k], v.default))
-
-        # put the default entries into the args dictionary
-        args = copy.deepcopy(args)
-        for path, val in defaults:
-            d = args
-            for path_item in path[:-1]:
-                d = d.setdefault(path_item, {})
-            if path[-1] not in d:
-                d[path[-1]] = val
+        """
+        is_recursive = is_recursive_schema(schema)
+        is_non_default = contains_non_default_schemas(schema)
+        if (not is_recursive) and is_non_default:
+            # throw a warning
+            args = fill_defaults(schema, args)
+        if is_recursive and is_non_default:
+            raise mm.ValidationError(
+                'Recursive schemas need to subclass argschema.DefaultSchema else defaults will not work')
 
         # load the dictionary via the schema
         result = schema.load(args)
@@ -101,14 +140,14 @@ class ArgSchemaParser(object):
 
     @staticmethod
     def initialize_logger(name, log_level):
-        '''initializes the logger to a level with a name
+        """initializes the logger to a level with a name
         logger = initialize_logger(name, log_level)
         inputs)
             name) name of the logger
             log_level) log level of the logger
         outputs)
             logger: a logging.Logger set with the name and level specified
-        '''
+        """
         level = logging.getLevelName(log_level)
 
         logging.basicConfig()
@@ -117,9 +156,9 @@ class ArgSchemaParser(object):
         return logger
 
     def run(self):
-        '''standin run method to illustrate what the arguments are after
+        """standin run method to illustrate what the arguments are after
         validation and parsing should overwrite in your subclass
         run() prints the arguments using json.dumps
-        '''
+        """
         print("running! with args")
         print(json.dumps(self.args, indent=2))

--- a/argschema/schemas.py
+++ b/argschema/schemas.py
@@ -2,11 +2,26 @@ import marshmallow as mm
 from .fields import LogLevel, InputFile, OutputFile
 
 
-class ArgSchema(mm.Schema):
-    '''The base marshmallow schema used by ArgSchemaParser to identify input and
-    output json files
+class DefaultSchema(mm.Schema):
+    """Schema class with support for making fields default to
+    values defined by that field's arguments.
+    """
+
+    @mm.pre_load
+    def make_object(self, in_data):
+        for name, field in self.fields.items():
+            if name not in in_data:
+                if field.default is not None:
+                    in_data[name] = field.default
+        return in_data
+
+
+class ArgSchema(DefaultSchema):
+    """The base marshmallow schema used by ArgSchemaParser to identify
+    input and output json files
     and the log_level
-    '''
+    """
+
     input_json = InputFile(
         metadata={'description': "file path of input json file"})
     output_json = OutputFile(


### PR DESCRIPTION
This addresses #9 backward compatibility in a different way than #8 defining explicit functions to check for recursiveness and for using DefaultSchema. 

argschema.schemas.DefaultSchema should be used to subclass any Schema to be used as a Nested schema within an ArgSchema. 

This PR reverts to the old behavior if the schema contains a non-DefaultSchema schema and is not recursively derived, it also spits out a warning declaring this behavior to be deprecated.  It raises an exception if it contains a non-DefaultSchema schema and is recursively defined (addressing #9).  It bypasses the old functionality if the schema contains no non-DefaultSchema based schemas (as will be the case most of the time with non-Nested Schemas) and defaults will load properly using the pre-load functionality attached to DefaultSchema.  

Also, I have changed it to initialize a logger with log_level =WARNING before I do validation, and then replace it with the specified log level afterwards so that I can raise the deprecation warning. 