### PR TITLE
multiple environment test support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,18 +19,17 @@ jobs:
 
     steps:
       - checkout
-
       # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
+      - run: pip install tox
 
       - run:
           name: install dependencies
           command: |
-            pip install tox
             tox --notest
             pip install -r requirements.txt
             pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           - v1-dependencies-{{ checksum "requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
-      - run: pip install tox
+      - run: pip install -U tox
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ workflows:
       - "python-2.7"
       - "python-3.6.1"
 
-  
-
 jobs:
   "python-3.6.1":
     working_directory: ~/repo
+    docker:
+        - image: circleci/python:3.6.1
     steps:
       - checkout
       # Download and cache dependencies
@@ -52,11 +52,12 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
-      docker:
-        - image: circleci/python:3.6.1
+      
 
   "python-2.7":
     working_directory: ~/repo
+    docker:
+      - image: circleci/python:2.7
     steps:
       - checkout
       # Download and cache dependencies
@@ -93,6 +94,5 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
-      docker:
-        - image: circleci/python:2.7
+
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,11 @@ workflows:
 
 shared: &shared
   working_directory: ~/repo
-  steps:
+  
+
+jobs:
+  "python-3.6.1":
+    steps:
     - checkout
     # Download and cache dependencies
     - restore_cache:
@@ -50,15 +54,46 @@ shared: &shared
     - store_artifacts:
         path: test-reports
         destination: test-reports
-
-jobs:
-  "python-3.6.1":
-    <<: *shared
     docker:
       - image: circleci/python:3.6.1
 
   "python-2.7":
-    <<: *shared
+    steps:
+    - checkout
+    # Download and cache dependencies
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
+
+    - run:
+        name: install dependencies
+        command: |
+          virtualenv venv
+          . venv/bin/activate
+          pip install -r requirements.txt
+          pip install -r test_requirements.txt
+
+    - save_cache:
+        paths:
+          - ~/repo/.venv
+        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+      
+    # run tests!
+    - run:
+        name: run tests
+        command: |
+          . venv/bin/activate
+          python setup.py test
+          bash <(curl -s https://codecov.io/bash)
+
+    - store_test_results:
+        path: test-reports
+
+    - store_artifacts:
+        path: test-reports
+        destination: test-reports
     docker:
       - image: circleci/python:2.7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+          - v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
           # fallback to using the latest cache if no exact match is found
-          - v2-dependencies-
+          - v3-dependencies-
 
       - run:
           name: install dependencies
@@ -38,9 +38,9 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/repo/venv
-            - ~/repo/tox
-          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+            - ~/repo/.venv
+            - ~/repo/.tox
+          key: v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@
 version: 2
 
 workflows:
+  version: 2
   build:
     jobs:
       - "python-2.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            pip install tox
             tox --notest
             pip install -r requirements.txt
             pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ build:
     - "python-2.7"
     - "python-3.6.1"
 
-shared:
+shared: &shared
   working_directory: ~/repo
   steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,12 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 version: 2
-build:
-  jobs:
-    - "python-2.7"
-    - "python-3.6.1"
+
+workflows:
+  build:
+    jobs:
+      - "python-2.7"
+      - "python-3.6.1"
 
 shared: &shared
   working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
           - v1-dependencies-{{ checksum "requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
-      - run: pip install -U tox
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -35,8 +35,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ./tox
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+            - .tox
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,82 +17,82 @@ jobs:
   "python-3.6.1":
     working_directory: ~/repo
     steps:
-    - checkout
-    # Download and cache dependencies
-    - restore_cache:
-        keys:
-        - python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-        # fallback to using the latest cache if no exact match is found
-        - python3-dependencies-
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+          # fallback to using the latest cache if no exact match is found
+          - python3-dependencies-
 
-    - run:
-        name: install dependencies
-        command: |
-          python -m venv venv
-          . venv/bin/activate
-          pip install -r requirements.txt
-          pip install -r test_requirements.txt
+      - run:
+          name: install dependencies
+          command: |
+            python -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            pip install -r test_requirements.txt
 
-    - save_cache:
-        paths:
-          - .venv
-        key: python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-      
-    # run tests!
-    - run:
-        name: run tests
-        command: |
-          . venv/bin/activate
-          python setup.py test
-          bash <(curl -s https://codecov.io/bash)
+      - save_cache:
+          paths:
+            - .venv
+          key: python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python setup.py test
+            bash <(curl -s https://codecov.io/bash)
 
-    - store_test_results:
-        path: test-reports
+      - store_test_results:
+          path: test-reports
 
-    - store_artifacts:
-        path: test-reports
-        destination: test-reports
-    docker:
-      - image: circleci/python:3.6.1
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+      docker:
+        - image: circleci/python:3.6.1
 
   "python-2.7":
     working_directory: ~/repo
     steps:
-    - checkout
-    # Download and cache dependencies
-    - restore_cache:
-        keys:
-        - python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-        # fallback to using the latest cache if no exact match is found
-        - python27-dependencies-
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+          # fallback to using the latest cache if no exact match is found
+          - python27-dependencies-
 
-    - run:
-        name: install dependencies
-        command: |
-          virtualenv venv
-          . venv/bin/activate
-          pip install -r requirements.txt
-          pip install -r test_requirements.txt
+      - run:
+          name: install dependencies
+          command: |
+            virtualenv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            pip install -r test_requirements.txt
 
-    - save_cache:
-        paths:
-          - .venv
-        key: python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-      
-    # run tests!
-    - run:
-        name: run tests
-        command: |
-          . venv/bin/activate
-          python setup.py test
-          bash <(curl -s https://codecov.io/bash)
+      - save_cache:
+          paths:
+            - .venv
+          key: python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python setup.py test
+            bash <(curl -s https://codecov.io/bash)
 
-    - store_test_results:
-        path: test-reports
+      - store_test_results:
+          path: test-reports
 
-    - store_artifacts:
-        path: test-reports
-        destination: test-reports
-    docker:
-      - image: circleci/python:2.7
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+      docker:
+        - image: circleci/python:2.7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,43 +5,43 @@
 version: 2
 shared:
   working_directory: ~/repo
+  build:
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
 
-  steps:
-    - checkout
-    # Download and cache dependencies
-    - restore_cache:
-        keys:
-        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-        # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            pip install -r test_requirements.txt
 
-    - run:
-        name: install dependencies
-        command: |
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install -r requirements.txt
-          pip install -r test_requirements.txt
+      - save_cache:
+          paths:
+            - ~/repo/.venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python setup.py test
+            bash <(curl -s https://codecov.io/bash)
 
-    - save_cache:
-        paths:
-          - ~/repo/.venv
-        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-      
-    # run tests!
-    - run:
-        name: run tests
-        command: |
-          . venv/bin/activate
-          python setup.py test
-          bash <(curl -s https://codecov.io/bash)
+      - store_test_results:
+          path: test-reports
 
-    - store_test_results:
-        path: test-reports
-
-    - store_artifacts:
-        path: test-reports
-        destination: test-reports
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
 
 jobs:
   "python-3.6.1":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
 
       - save_cache:
           paths:
-            - .venv
-            - .tox
+            - ~/repo/venv
+            - ~/repo/tox
           key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,45 +3,49 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 version: 2
+build:
+  jobs:
+    - "python-2.7"
+    - "python-3.6.1"
+
 shared:
   working_directory: ~/repo
-  build:
-    steps:
-      - checkout
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+  steps:
+    - checkout
+    # Download and cache dependencies
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
 
-      - run:
-          name: install dependencies
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
-            pip install -r test_requirements.txt
+    - run:
+        name: install dependencies
+        command: |
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install -r requirements.txt
+          pip install -r test_requirements.txt
 
-      - save_cache:
-          paths:
-            - ~/repo/.venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-        
-      # run tests!
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            python setup.py test
-            bash <(curl -s https://codecov.io/bash)
+    - save_cache:
+        paths:
+          - ~/repo/.venv
+        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+      
+    # run tests!
+    - run:
+        name: run tests
+        command: |
+          . venv/bin/activate
+          python setup.py test
+          bash <(curl -s https://codecov.io/bash)
 
-      - store_test_results:
-          path: test-reports
+    - store_test_results:
+        path: test-reports
 
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
+    - store_artifacts:
+        path: test-reports
+        destination: test-reports
 
 jobs:
   "python-3.6.1":
@@ -53,3 +57,4 @@ jobs:
     <<: *shared
     docker:
       - image: circleci/python:2.7
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.venv
-            - ~/.tox
+            - .venv
+            - .tox
           key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
     # Download and cache dependencies
     - restore_cache:
         keys:
-        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        - v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
+        - v3-dependencies-
 
     - run:
         name: install dependencies
@@ -38,7 +38,7 @@ jobs:
     - save_cache:
         paths:
           - ~/repo/.venv
-        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        key: v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
       
     # run tests!
     - run:
@@ -63,9 +63,9 @@ jobs:
     # Download and cache dependencies
     - restore_cache:
         keys:
-        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        - v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
+        - v2-dependencies-
 
     - run:
         name: install dependencies
@@ -78,7 +78,7 @@ jobs:
     - save_cache:
         paths:
           - ~/repo/.venv
-        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
       
     # run tests!
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
     # Download and cache dependencies
     - restore_cache:
         keys:
-        - v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        - python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         # fallback to using the latest cache if no exact match is found
-        - v3-dependencies-
+        - python3-dependencies-
 
     - run:
         name: install dependencies
@@ -38,7 +38,7 @@ jobs:
     - save_cache:
         paths:
           - ~/repo/.venv
-        key: v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        key: python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
       
     # run tests!
     - run:
@@ -63,9 +63,9 @@ jobs:
     # Download and cache dependencies
     - restore_cache:
         keys:
-        - v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        - python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         # fallback to using the latest cache if no exact match is found
-        - v2-dependencies-
+        - python27-dependencies-
 
     - run:
         name: install dependencies
@@ -78,7 +78,7 @@ jobs:
     - save_cache:
         paths:
           - ~/repo/.venv
-        key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        key: python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
       
     # run tests!
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,58 +3,53 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 version: 2
-jobs:
-  build:
-    docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
+shared:
+  working_directory: ~/repo
+
+  steps:
+    - checkout
+    # Download and cache dependencies
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
+
+    - run:
+        name: install dependencies
+        command: |
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install -r requirements.txt
+          pip install -r test_requirements.txt
+
+    - save_cache:
+        paths:
+          - ~/repo/.venv
+        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
       
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+    # run tests!
+    - run:
+        name: run tests
+        command: |
+          . venv/bin/activate
+          python setup.py test
+          bash <(curl -s https://codecov.io/bash)
 
-    working_directory: ~/repo
+    - store_test_results:
+        path: test-reports
 
-    steps:
-      - checkout
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-          # fallback to using the latest cache if no exact match is found
-          - v3-dependencies-
+    - store_artifacts:
+        path: test-reports
+        destination: test-reports
 
-      - run:
-          name: install dependencies
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install tox
-            tox --notest
-            pip install -r requirements.txt
-            pip install -r test_requirements.txt
+jobs:
+  "python-3.6.1":
+    <<: *shared
+    docker:
+      - image: circleci/python:3.6.1
 
-      - save_cache:
-          paths:
-            - ~/repo/.venv
-            - ~/repo/.tox
-          key: v3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
-        
-      # run tests!
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            tox
-            bash <(curl -s https://codecov.io/bash)
-
-      - store_test_results:
-          path: test-reports
-
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
-
-            
+  "python-2.7":
+    <<: *shared
+    docker:
+      - image: circleci/python:2.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,19 +29,24 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install tox
             tox --notest
             pip install -r requirements.txt
             pip install -r test_requirements.txt
 
       - save_cache:
           paths:
-            - .tox
+            - ~/.venv
+            - ~/.tox
           key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!
       - run:
           name: run tests
           command: |
+            . venv/bin/activate
             tox
             bash <(curl -s https://codecov.io/bash)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,11 @@ workflows:
       - "python-2.7"
       - "python-3.6.1"
 
-shared: &shared
-  working_directory: ~/repo
   
 
 jobs:
   "python-3.6.1":
+    working_directory: ~/repo
     steps:
     - checkout
     # Download and cache dependencies
@@ -57,6 +56,7 @@ jobs:
       - image: circleci/python:3.6.1
 
   "python-2.7":
+    working_directory: ~/repo
     steps:
     - checkout
     # Download and cache dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+          - v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-dependencies-
 
       - run:
           name: install dependencies
@@ -40,7 +40,7 @@ jobs:
           paths:
             - ~/repo/venv
             - ~/repo/tox
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
     - run:
         name: install dependencies
         command: |
-          sudo pip install virtualenv
           python -m venv venv
           . venv/bin/activate
           pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
     - save_cache:
         paths:
-          - ~/repo/.venv
+          - .venv
         key: python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
       
     # run tests!
@@ -76,7 +76,7 @@ jobs:
 
     - save_cache:
         paths:
-          - ~/repo/.venv
+          - .venv
         key: python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
       
     # run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            python -m venv venv
+            python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
             pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ shared: &shared
     - run:
         name: install dependencies
         command: |
-          python3 -m venv venv
+          python -m venv venv
           . venv/bin/activate
           pip install -r requirements.txt
           pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
       - save_cache:
           paths:
-            - .venv
+            - ./venv
           key: python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!
@@ -77,7 +77,7 @@ jobs:
 
       - save_cache:
           paths:
-            - .venv
+            - ./venv
           key: python27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
         
       # run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,22 +30,20 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
+            tox --notest
             pip install -r requirements.txt
-            pip install -r test/test_requirements.txt
+            pip install -r test_requirements.txt
 
       - save_cache:
           paths:
-            - ./venv
+            - ./tox
           key: v1-dependencies-{{ checksum "requirements.txt" }}
         
       # run tests!
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python setup.py test
+            tox
             bash <(curl -s https://codecov.io/bash)
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ shared: &shared
     - run:
         name: install dependencies
         command: |
+          sudo pip install virtualenv
           python -m venv venv
           . venv/bin/activate
           pip install -r requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include test_requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 marshmallow
 numpy
 sphinxcontrib-napoleon
+tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-marshmallow
 numpy
+marshmallow
 sphinxcontrib-napoleon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+sphinxcontrib-napoleon
 numpy
 marshmallow
-sphinxcontrib-napoleon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 marshmallow
 numpy
 sphinxcontrib-napoleon
-tox

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 with open('requirements.txt', 'r') as f:
     required = f.read().splitlines()
 
-with open('test/test_requirements.txt','r') as f:
+with open('test_requirements.txt','r') as f:
     test_required = f.read().splitlines()
 
 setup(name='argschema',

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,8 +6,6 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
-def test_trivial():
-    print("testing trivial for cache")
 
 def test_bad_path():
     with pytest.raises(mm.ValidationError):

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,6 +6,8 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
+def test_fail_python3():
+    print 'bad python3'
 
 def test_bad_path():
     with pytest.raises(mm.ValidationError):

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,8 +6,6 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
-def test_fail_python3():
-    print 'bad python3'
 
 def test_bad_path():
     with pytest.raises(mm.ValidationError):

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,6 +6,8 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
+def test_trivial():
+    print("testing trivial for cache")
 
 def test_bad_path():
     with pytest.raises(mm.ValidationError):

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,7 +6,9 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
-
+def test_check_cache():
+    pass
+    
 def test_bad_path():
     with pytest.raises(mm.ValidationError):
         example = {

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,9 +6,6 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
-def test_check_cache():
-    pass
-    
 def test_bad_path():
     with pytest.raises(mm.ValidationError):
         example = {

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,8 +6,6 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
-def test_trivial():
-    print("adding new trivial test to test caching")
 
 def test_bad_path():
     with pytest.raises(mm.ValidationError):

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,9 +6,6 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
-def test_trivial():
-    print("testing trivial for cache")
-
 def test_bad_path():
     with pytest.raises(mm.ValidationError):
         example = {

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -6,6 +6,9 @@ import marshmallow as mm
 from argschema import ArgSchemaParser, ArgSchema
 import argschema
 
+def test_trivial():
+    print("adding new trivial test to test caching")
+
 def test_bad_path():
     with pytest.raises(mm.ValidationError):
         example = {

--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -1,9 +1,0 @@
-coverage>=4.1
-mock>=2.0.0
-pep8>=1.7.0
-pytest>=3.0.7
-pytest-cov>=2.2.1
-pytest-pep8>=1.0.6
-pytest-xdist>=1.14
-flake8>=3.0.4
-pylint>=1.5.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,9 @@
+coverage>=4.1
+mock>=2.0.0
+pep8>=1.7.0
+pytest>=3.0.7
+pytest-cov>=2.2.1
+pytest-pep8>=1.0.6
+pytest-xdist>=1.14
+flake8>=3.0.4
+pylint>=1.5.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coverage>=4.1
+coverage>=4.0
 mock>=2.0.0
 pep8>=1.7.0
 pytest>=3.0.7

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 coverage>=4.0
 mock>=2.0.0
-pep8>=1.7.0
 pytest>=3.0.7
+pep8>=1.7.0
 pytest-cov>=2.2.1
 pytest-pep8>=1.0.6
 pytest-xdist>=1.14

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,5 +5,6 @@ pep8>=1.7.0
 pytest-cov>=2.2.1
 pytest-pep8>=1.0.6
 pytest-xdist>=1.14
-flake8>=3.0.4
 pylint>=1.5.4
+flake8>=3.0.4
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py36
+
+[testenv]
+commands = pytest
+deps =
+    -rrequirements.txt
+    -rtest_requirements.txt


### PR DESCRIPTION
I have added support for running tests in multiple environments through the use of tox, with tox installed, you should just be able to test all environments with "tox".  Also, I reconfigured the circleci build to do tests of python2.7 and python3.6 using a parallel build workflow.  Forgive me for the excessive number of commits, but when testing CI infrastructure I had to commit many times to test it working correctly. 