### PR TITLE
fix Dockerfile.test for bamboo based testing

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,9 +4,8 @@ RUN mkdir -p /usr/local/argschema
 COPY . /usr/local/argschema
 WORKDIR /usr/local/argschema
 RUN python setup.py install 
-WORKDIR test
-RUN pip install --disable-pip-version-check -U setuptools
 RUN pip install -r test_requirements.txt --upgrade
+RUN pip install --disable-pip-version-check -U setuptools
 RUN useradd -ms /bin/bash test
 RUN chmod -R 777 ..
 USER test


### PR DESCRIPTION
wrote this .test dockerfile to install testing requirements for bamboo based workflow, forgot to modify when i moved the test_requirements up a folder.   Passed CircleCi but not bamboo, which is why i missed it.