### PR TITLE
removing sphnix from requirements and adding a test_requirements.txt

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,0 +1,3 @@
+sphinxcontrib-napoleon
+numpy
+marshmallow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-sphinxcontrib-napoleon
 numpy
 marshmallow


### PR DESCRIPTION
this removes sphinxcontrib-napoleon from getting installed when building the library.  Will change RTD to read the new requirements file.