### PR TITLE
Bug/david nested

### DIFF
--- a/argschema/schemas.py
+++ b/argschema/schemas.py
@@ -24,7 +24,7 @@ class DefaultSchema(mm.Schema):
         """
         for name, field in self.fields.items():
             if name not in in_data:
-                if field.default is not None:
+                if field.default is not mm.missing:
                     in_data[name] = field.default
         return in_data
 

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -17,7 +17,7 @@ def args_to_dict(argsobj):
     ----------
     argsobj : argparse.Namespace
         Namespace object returned by standard argparse.parse function
-        
+
 
     Returns
     -------
@@ -77,11 +77,11 @@ def do_join(a, b, key, merge_keys=None):
     Parameters
     ----------
     a :
-        
+
     b :
-        
+
     key :
-        
+
     merge_keys :
          (Default value = None)
 
@@ -175,11 +175,10 @@ def build_schema_arguments(schema, arguments=None, path=None):
         if isinstance(field, mm.fields.Nested):
             if field.many:
                 logging.warning("many=True not supported from argparse")
-                return
-
-            build_schema_arguments(field.schema,
-                                   arguments,
-                                   path + [field_name])
+            else:
+                build_schema_arguments(field.schema,
+                                       arguments,
+                                       path + [field_name])
         else:
             # it's not an object, so build the argument
             arg = {}

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -214,3 +214,42 @@ def bad_test_recursive_schema():
         mod = ArgSchemaParser(input_data=recursive_data,
                             schema_type=BadExampleRecursiveSchema, args=[])
 
+
+class ModelFit(argschema.schemas.DefaultSchema):
+    fit_type = argschema.fields.Str(description="")
+    hof_fit = argschema.fields.InputFile(description="")
+    hof = argschema.fields.InputFile(description="")
+
+
+class PopulationSelectionPaths(argschema.schemas.DefaultSchema):
+    fits = argschema.fields.Nested(ModelFit, description="", many=True)
+
+
+class PopulationSelectionParameters(argschema.ArgSchema):
+    paths = argschema.fields.Nested(PopulationSelectionPaths)
+
+
+david_data ={
+    'paths':{
+        'fits':[{
+            'fit_type':'test',
+            'hof_fit':'requirements.txt',
+            'hof':'requirements.txt'
+        },
+        {
+            'fit_type':'test2',
+            'hof_fit':'requirements.txt',
+            'hof':'requirements.txt'
+        }
+        ]
+    }
+}
+
+def test_david_example(tmpdir_factory):
+    file_ = tmpdir_factory.mktemp('test').join('testinput.json')
+    file_.write(json.dumps(david_data))
+    args = ['--input_json', str(file_)]
+    mod = argschema.ArgSchemaParser(schema_type=PopulationSelectionParameters,args=args)
+    print(mod.args)
+    assert(len(mod.args['paths']['fits'])==1)
+

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -251,5 +251,5 @@ def test_david_example(tmpdir_factory):
     args = ['--input_json', str(file_)]
     mod = argschema.ArgSchemaParser(schema_type=PopulationSelectionParameters,args=args)
     print(mod.args)
-    assert(len(mod.args['paths']['fits'])==1)
+    assert(len(mod.args['paths']['fits'])==2)
 


### PR DESCRIPTION
added a test that includes david's example which was broken, with multiple nested schemas, with no defaults given.  Added fixes that make sure non-default fields are not filled in upon deserialization with mm.missing, thereby breaking smart_merge.  Also fixed a related bug that didn't fill our argparse arguments at levels of a nested schema where there was a single Nested(many=True) schema, because the recursive function was returning preemptively, rather than just skipping that field.