### PR TITLE
Auto increment circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
           filters:
             branches:
               only:
-                  - auto_inc_circleci
+                  - master
 
 jobs:
   increment:

--- a/.circleci/increment_version.py
+++ b/.circleci/increment_version.py
@@ -18,4 +18,4 @@ if __name__ == "__main__":
     os.system("git commit -m '[ci skip] Increase version to {}'"
               .format(new_version))
 
-    os.system("git push")
+    os.system("git push origin master")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('test_requirements.txt','r') as f:
     test_required = f.read().splitlines()
 
 setup(name='argschema',
-      version='1.11',
+      version='1.12',
       description=' a wrapper for setting up modules that can have parameters specified by command line arguments,\
        json_files, or dictionary objects. Providing a common wrapper for data processing modules.',
       author='Forrest Collman,David Feng',


### PR DESCRIPTION
I have added a step in circle ci that will auto-increment the most minor version number after it passes tests only on the master branch, this will keep our versions bumping as we successfully merge into master and pass tests.  Next step, auto-publishing to pypi.