### PR TITLE
Feature/simple description

### DIFF
--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -187,6 +187,11 @@ def build_schema_arguments(schema, arguments=None, path=None):
             md = field.metadata.get('metadata', {})
             if 'description' in md:
                 arg['help'] = md['description']
+            #also look to see if description was added a kwarg
+            else:
+                print('falling back')
+                if 'description' in field.metadata:
+                    arg['help'] = field.metadata.get('description')
 
             field_type = type(field)
             if isinstance(field, mm.fields.List):

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -189,7 +189,6 @@ def build_schema_arguments(schema, arguments=None, path=None):
                 arg['help'] = md['description']
             #also look to see if description was added a kwarg
             else:
-                print('falling back')
                 if 'description' in field.metadata:
                     arg['help'] = field.metadata.get('description')
 

--- a/examples/mymodule.py
+++ b/examples/mymodule.py
@@ -1,8 +1,7 @@
 import argschema
 
 class MySchema(argschema.ArgSchema):
-    a = argschema.fields.Int(default = 42, 
-                            metadata = {'description':'my first parameter'})
+    a = argschema.fields.Int(default = 42, description= 'my first parameter')
                             
 if __name__ == '__main__':
     mod = argschema.ArgSchemaParser(schema_type=MySchema)

--- a/examples/template_module.py
+++ b/examples/template_module.py
@@ -6,12 +6,9 @@ import json
 
 # these are the core parameters for my module
 class MyNestedParameters(DefaultSchema):
-    name = Str(required=True, metadata={
-        'description': 'name of vector'})
-    increment = Int(required=True, metadata={
-        'description': 'value to increment'})
-    array = NumpyArray(dtype=np.float, required=True, metadata={
-                       'description': 'array to increment'})
+    name = Str(required=True, description='name of vector')
+    increment = Int(required=True, description='value to increment')
+    array = NumpyArray(dtype=np.float, required=True, description='array to increment')
     write_output = Boolean(required=False, default=True)
 
 # but i'm going to nest them inside a subsection called inc
@@ -22,8 +19,7 @@ class MyParameters(ArgSchema):
 class MyOutputParams(DefaultSchema):
     name = Str(required=True, metadata={
         'description': 'name of vector'})
-    inc_array = NumpyArray(dtype=np.float, required=True, metadata={
-                           'description': 'incremented array'})
+    inc_array = NumpyArray(dtype=np.float, required=True, description='incremented array')
 
 if __name__ == '__main__':
     

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('test_requirements.txt','r') as f:
     test_required = f.read().splitlines()
 
 setup(name='argschema',
-      version='1.13.11',
+      version='1.14.0',
       description=' a wrapper for setting up modules that can have parameters specified by command line arguments,\
        json_files, or dictionary objects. Providing a common wrapper for data processing modules.',
       author='Forrest Collman,David Feng',

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -253,3 +253,12 @@ def test_david_example(tmpdir_factory):
     print(mod.args)
     assert(len(mod.args['paths']['fits'])==2)
 
+class MyShorterExtension(ArgSchema):
+    a = mm.fields.Str(description='a string')
+    b = mm.fields.Int(description='an integer')
+    c = mm.fields.Int(description='an integer', default=10)
+    d = mm.fields.List(mm.fields.Int, description='a list of integers')
+
+def test_simple_description():
+    mod = argschema.ArgSchemaParser(schema_type=MyShorterExtension,args=['--help'])
+    

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -260,5 +260,9 @@ class MyShorterExtension(ArgSchema):
     d = mm.fields.List(mm.fields.Int, description='a list of integers')
 
 def test_simple_description():
-    mod = argschema.ArgSchemaParser(schema_type=MyShorterExtension,args=['--help'])
-    
+    d =    {
+            'a': "hello",
+            'b': 1,
+            'd': [1, 5, 4]
+        }
+    mod = argschema.ArgSchemaParser(input_data = d, schema_type=MyShorterExtension)


### PR DESCRIPTION
This allows users to specify the description via the simplier api of just description= 'my description' rather than the more verbose metadata={'description':'my description'}.  The change is backward compatible.  I just noticed that David was using this syntax already, although it was broken for him, now it would work, and it makes it a lot simplier to type.  Marshmallow supports natively by putting all keyword arguments in the metadata dictionary. 