### PR TITLE
Feature/better sorting

### DIFF
--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -227,9 +227,11 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
             if field.required:
                 arg['help']+= " (REQUIRED)"
             for validator in field.validators:
+                if isinstance(validator,mm.validate.ContainsOnly):
+                    arg['help']+= " (constrained list)"
                 if isinstance(validator,mm.validate.OneOf):
                     arg['help']+= " (valid options are {})".format(validator.choices)
-        
+
             field_type = type(field)
             if isinstance(field, mm.fields.List):
                 arg['nargs'] = '*'

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -175,37 +175,48 @@ def get_description_from_field(field):
     return desc
             
 def build_schema_arguments(schema, arguments=None, path=None, description =None):
-    """given a jsonschema, create a dictionary of argparse arguments (recursive function)
+    """given a jsonschema, create a dictionary of argparse arguments,
+    by navigating down the Nested schema tree. (recursive function) 
 
     Parameters
     ----------
-    path :
-        list or None (Default value = None)
-    schema :
-        marshmallow schema with metadata['description'] filled in with help values
-    arguments :
-        (Default value = None)
+    schema : marshamallow.schema.Schema
+        schema with field.description filled in with help values
+    arguments : list or None
+        list of argument group dictionaries to add to (see Returns) (Default value = None)
+    path : list or None
+        list of strings denoted where you are in the tree (Default value = None)
+    description: str or None
+        description for the argument group at this level of the tree
 
     Returns
     -------
-    collections.OrderedDict
-        OrderedDict of dictionaries with kwargs to build argparse arguments
+    list
+        List of argument group dictionaries, with keys ['title','description','args'] 
+        which contain the arguments for argparse.  'args' is an OrderedDict of dictionaries
+        with keys of the argument names with kwargs to build an argparse argument
 
     """
     path = [] if path is None else path
     arguments = [] if arguments is None else arguments
     arggroup = {}
+    #name this argument group by the path, or the schema class name if it's the root
     if len(path)==0:
         arggroup['title']=schema.__class__.__name__
     else:
         arggroup['title']='.'.join(path)
     arggroup['args']=collections.OrderedDict()
+    #assume the description has been handed down
     arggroup['description']=description
 
+    #sort the fields first by required, then by default values present or not
     for field_name, field in sorted(schema.declared_fields.items(),
                                     key= lambda x: 2*x[1].required+1*(x[1].default==mm.missing),
                                     reverse=True):
+        #get this field's description
         desc = get_description_from_field(field)
+
+        #if its nested, then we want to recusively follow this link
         if isinstance(field, mm.fields.Nested):
             if field.many:
                 logging.warning("many=True not supported from argparse")
@@ -215,13 +226,15 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
                                        path + [field_name],
                                        description = desc)
         else:
-            # it's not an object, so build the argument
+            # it's not nested then let's build the argument
             arg = {}
             arg_name = '--' + '.'.join(path + [field_name])
             if desc is not None:
                 arg['help']=desc
             else:
                 arg['help']=''
+
+            #programatically add helpful notes to help string
             if field.default is not mm.missing:
                 arg['help']+= " (default={})".format(field.default)
             if field.required:
@@ -232,6 +245,7 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
                 if isinstance(validator,mm.validate.OneOf):
                     arg['help']+= " (valid options are {})".format(validator.choices)
 
+            #catch lists to figure out desired type
             field_type = type(field)
             if isinstance(field, mm.fields.List):
                 arg['nargs'] = '*'
@@ -250,13 +264,19 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
                 else:
                     logging.warning("List contains unsupported type: %s" % str(
                         type(field.container)))
+            #otherwise look up the desired type in FIELD_TYPE_MAP
             elif type(field) in FIELD_TYPE_MAP:
                 # it's a simple type, apply the mapping
                 arg['type'] = FIELD_TYPE_MAP[field_type]
 
+            #DON'T WANT TO USE DEFAULT VALUES AS ARGPARSE OVERRULES JSON
             # if field.default != mm.missing:
             #    arg['default'] = field.default
+
+            #add this argument to the arggroup
             arggroup['args'][arg_name] = arg
+    
+    #tack on this arggroup to the list and return
     arguments.append(arggroup)
     return arguments
 
@@ -276,7 +296,12 @@ def schema_argparser(schema):
 
     """
 
+    #build up a list of argument groups using recursive function
+    #to traverse the tree, root node gets the description given by doc string
+    #of the schema
     arguments = build_schema_arguments(schema,description=schema.__doc__)
+    #make the root schema appeear first rather than last
+    arguments = [arguments[-1]]+arguments[0:-1]
 
     parser = argparse.ArgumentParser()
 

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -196,7 +196,7 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
     arguments = [] if arguments is None else arguments
     arggroup = {}
     if len(path)==0:
-        arggroup['title']='root'
+        arggroup['title']=schema.__class__.__name__
     else:
         arggroup['title']='.'.join(path)
     arggroup['args']=collections.OrderedDict()
@@ -276,7 +276,7 @@ def schema_argparser(schema):
 
     """
 
-    arguments = build_schema_arguments(schema)
+    arguments = build_schema_arguments(schema,description=schema.__doc__)
 
     parser = argparse.ArgumentParser()
 

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -220,6 +220,8 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
             arg_name = '--' + '.'.join(path + [field_name])
             if desc is not None:
                 arg['help']=desc
+            else:
+                arg['help']=''
             if field.default is not mm.missing:
                 arg['help']+= " (default={})".format(field.default)
             if field.required:


### PR DESCRIPTION
Here is my proposed solution to #36 . 

This program (test_schema.py)

```Python
    import argschema
    import marshmallow as mm

    class NestedSchema(argschema.schemas.DefaultSchema):
        aint = argschema.fields.Int(required=False, default =5, description="a integer")
        bstr = argschema.fields.Str(required=True, 
                                    validate=mm.validate.OneOf(["a","b","c"]),
                                    description = "a string")
        cstr = argschema.fields.Str(required=True, 
                                validate=mm.validate.ContainsOnly(["true","false","maybe"]),
                                description = "a list of whether statements are true/false/maybe")                        

    class MySchema(argschema.ArgSchema):
        """my set of parameters"""
        nest = argschema.fields.Nested(NestedSchema, required=True, description="nested schema")
        topint = argschema.fields.Int(required=True,description="a top integer")
        topintb = argschema.fields.Int(default=5,required=False,description="a top integer b")
        topintc = argschema.fields.Int(required=True,description="a top integer c")
        topintd = argschema.fields.Int(default=7,required=False,description="a top integer d")

    if __name__ == '__main__':
        mod = argschema.ArgSchemaParser(schema_type=MySchema)
```

now results in 

```Shell
    $ python test_schema.py  -h
    usage: test_schema.py [-h] [--nest.cstr NEST.CSTR] [--nest.bstr NEST.BSTR]
                        [--nest.aint NEST.AINT] [--topintc TOPINTC]
                        [--topint TOPINT] [--input_json INPUT_JSON]
                        [--output_json OUTPUT_JSON] [--log_level LOG_LEVEL]
                        [--topintb TOPINTB] [--topintd TOPINTD]

    optional arguments:
    -h, --help            show this help message and exit

    nest:
    nested schema

    --nest.cstr NEST.CSTR
                            a list of whether statements are true/false/maybe
                            (REQUIRED) (constrained list) (valid options are
                            ['true', 'false', 'maybe'])
    --nest.bstr NEST.BSTR
                            a string (REQUIRED) (valid options are ['a', 'b',
                            'c'])
    --nest.aint NEST.AINT
                            a integer (default=5)

    MySchema:
    my set of parameters

    --topintc TOPINTC     a top integer c (REQUIRED)
    --topint TOPINT       a top integer (REQUIRED)
    --input_json INPUT_JSON
                            file path of input json file
    --output_json OUTPUT_JSON
                            file path to output json file
    --log_level LOG_LEVEL
                            set the logging level of the module (default=ERROR)
    --topintb TOPINTB     a top integer b (default=5)
    --topintd TOPINTD     a top integer d (default=7)
```