### PR TITLE
Autodoc

### DIFF
--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -128,16 +128,16 @@ class ArgSchemaParser(object):
     -------
 
     """
-
+    
     def __init__(self,
                  input_data=None,  # dictionary input as option instead of --input_json
                  schema_type=schemas.ArgSchema,  # schema for parsing arguments
                  output_schema_type = None, # schema for parsing output_json
                  args=None,
                  logger_name=__name__):
-
+        
         schema = schema_type()
-
+        self.schema = schema
         # convert schema to argparse object
         p = utils.schema_argparser(schema)
         argsobj = p.parse_args(args)

--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -111,6 +111,9 @@ class ArgSchemaParser(object):
     Takes input_data, reference to a input_json and the command line inputs and parses out the parameters
     and validates them against the schema_type specified.
 
+    To subclass this and make a new schema be default, simply override the schema_type and output_schema_type
+    attributes of this class.
+    
     Parameters
     ----------
     input_data : dict or None
@@ -128,16 +131,21 @@ class ArgSchemaParser(object):
     -------
 
     """
-    
+    schema_type = schemas.ArgSchema
+    output_schema_type = None
+
     def __init__(self,
                  input_data=None,  # dictionary input as option instead of --input_json
-                 schema_type=schemas.ArgSchema,  # schema for parsing arguments
+                 schema_type=None,  # schema for parsing arguments
                  output_schema_type = None, # schema for parsing output_json
                  args=None,
                  logger_name=__name__):
         
-        schema = schema_type()
+        if schema_type is not None:
+            self.schema_type = schema_type
+        schema = self.schema_type()
         self.schema = schema
+
         # convert schema to argparse object
         p = utils.schema_argparser(schema)
         argsobj = p.parse_args(args)

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -40,8 +40,8 @@ def process_schemas(app, what, name, obj, options, lines):
             #lines.append("")
             #lines.append("  keys: (field_type \: raw_type) description")
             lines.append(".. csv-table:: %s"%obj.__name__)
-            lines.append('   :header: "key", "description", "default","type"')
-            lines.append('   :widths: 30, 80, 30, 30')
+            lines.append('   :header: "key", "description", "default","field_type","raw_type"')
+            lines.append('   :widths: 30, 80, 30, 30, 30')
             lines.append('')
             
 
@@ -81,17 +81,19 @@ def process_schemas(app, what, name, obj, options, lines):
                     else:
                         base_types = inspect.getmro(type(field))
             
-                
+                    field_type = type(field)
                     #use these base_types to figure out the raw_json type for this field
                     if isinstance(field,mm.fields.Nested):
                         #if it's a nested field we should specify it as a dict, and link to the documentation 
                         #for that nested schema
-                        schema_type = type(field.schema)
-                        schema_class_name = schema_type.__module__ + "." + schema_type.__name__
+                        # = type
+                        #schema_type = type(field.schema)
+                        field_type = type(field.schema)
+                        #schema_class_name = schema_type.__module__ + "." + schema_type.__name__
                         if field.many == True:
-                           raw_type = 'list[:class:`~{}`]'.format(schema_class_name)
+                           raw_type = 'list'
                         else:
-                           raw_type = 'dict(:class:`~{}`)'.format(schema_class_name)
+                           raw_type = 'dict'
                     else:
                         #otherwise we should be able to look it up in the FIELD_TYPE_MAP
                         try:
@@ -101,10 +103,10 @@ def process_schemas(app, what, name, obj, options, lines):
                             #if its not in the FIELD_TYPE_MAP, we aren't sure what type it is
                             #TODO handle this more elegantly/and/or patch up more use cases
                             raw_type = '?'
-                    field_line += ":class:`{}.{}` : {}".format(type(field).__module__,type(field).__name__,raw_type)
+                    field_line += ":class:`~{}.{}`,{}".format(field_type.__module__,field_type.__name__,raw_type)
                 except:
                     #in case this fails for some reason, note it as unknown
                     #TODO handle this more elegantly, identify and patch up such cases
-                    field_line += "unknown"
+                    field_line += "unknown,unknown"
                 lines.append(field_line)
             #lines.append(table_line)

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -1,0 +1,55 @@
+from schemas import ArgSchema
+import fields
+import marshmallow as mm
+from utils import get_description_from_field
+from argschema_parser import ArgSchemaParser
+import inspect
+
+FIELD_TYPE_MAP = {v: k for k, v in mm.Schema.TYPE_MAPPING.items()}
+
+def process_schemas(app, what, name, obj, options, lines):
+
+    if what == "class":
+        if issubclass(obj,ArgSchemaParser):
+            lines.append("   This class takes a ArgSchema as an input to parse inputs")
+            (args,vargs,varkw,defaults)=inspect.getargspec(obj.__init__)
+            def_schema = defaults[1].__module__+'.'+defaults[1].__name__
+            lines.append("   This class's default ArgSchema is of type :class:`{}`".format(def_schema))
+            lines.append("")
+        if issubclass(obj,ArgSchema):
+            lines.append("   This schema is designed to be a schema_type for an ArgSchemaParser object")
+            lines.append("")
+        if issubclass(obj,mm.Schema):
+            schema = obj()
+            lines.append("Schema:")
+            for field_name, field in schema.declared_fields.items():
+                
+                field_line = "  :%s: "%field_name
+                try:
+                    if isinstance(field, mm.fields.List):
+                        base_types = inspect.getmro(type(field.container))
+                    else:
+                        base_types = inspect.getmro(type(field))
+                  
+                    if isinstance(field,mm.fields.Nested):
+                        raw_type = 'dict(:class:`~{}`)'.format(type(field.schema).__name__)
+                    else:
+                        try:
+                            base_type=next(bt for bt in base_types if bt in FIELD_TYPE_MAP)
+                            raw_type=FIELD_TYPE_MAP[base_type].__name__
+                        except:
+                            raw_type = '?'
+                    field_line += "(:class:`{}.{}` : {}) ".format(type(field).__module__,type(field).__name__,raw_type)
+                except:
+                    field_line += "fail "
+                description = get_description_from_field(field)
+                if description is not None:
+                    field_line+=description
+                else:
+                    field_line+="no description "
+                if field.required:
+                    field_line += " REQUIRED "
+                if field.default is not mm.missing:
+                    field_line += " (default = {})".format(field.default)
+                lines.append(field_line)
+            

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -57,10 +57,12 @@ def process_schemas(app, what, name, obj, options, lines):
                     if isinstance(field,mm.fields.Nested):
                         #if it's a nested field we should specify it as a dict, and link to the documentation 
                         #for that nested schema
+                        schema_type = type(field.schema)
+                        schema_class_name = schema_type.__module__ + "." + schema_type.__name__
                         if field.many == True:
-                           raw_type = 'list[:class:`~{}`]'.format(type(field.schema).__name__)
+                           raw_type = 'list[:class:`~{}`]'.format(schema_class_name)
                         else:
-                           raw_type = 'dict(:class:`~{}`)'.format(type(field.schema).__name__)
+                           raw_type = 'dict(:class:`~{}`)'.format(schema_class_name)
                     else:
                         #otherwise we should be able to look it up in the FIELD_TYPE_MAP
                         try:

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -1,8 +1,7 @@
-from schemas import ArgSchema
-import fields
+from argschema.schemas import ArgSchema
 import marshmallow as mm
-from utils import get_description_from_field
-from argschema_parser import ArgSchemaParser
+from argschema.utils import get_description_from_field
+from argschema.argschema_parser import ArgSchemaParser
 import inspect
 
 FIELD_TYPE_MAP = {v: k for k, v in mm.Schema.TYPE_MAPPING.items()}

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -36,15 +36,43 @@ def process_schemas(app, what, name, obj, options, lines):
         if issubclass(obj,mm.Schema):
             #but document all mm.Schema's
             schema = obj()
-            lines.append(".. note::")
-            lines.append("")
-            lines.append("  keys: (field_type \: raw_type) description")
+            #lines.append(".. note::")
+            #lines.append("")
+            #lines.append("  keys: (field_type \: raw_type) description")
+            lines.append(".. csv-table:: %s"%obj.__name__)
+            lines.append('   :header: "key", "description", "default","type"')
+            lines.append('   :widths: 30, 80, 30, 30')
+            lines.append('')
+            
 
-            #loop over the declared fields for this schema
+            # #loop over the declared fields for this schema
             for field_name, field in schema.declared_fields.items():
                 #we will build up the documentation line for each field
                 #start declaring the key as field_name like a parameter
-                field_line = "    :%s: "%field_name
+                field_line = "    %s,"%field_name
+               
+                #get the description of this field and add it to documentation
+                description = get_description_from_field(field)
+                
+                if description is None:
+                    description="no description"         
+                field_line+='"%s",'%description
+    
+
+                #if field.required:
+                #    #add a REQUIRED stamp to required fields
+                #    field_line += " REQUIRED "
+                if field.default is not mm.missing:
+                    #add in the default value if there is one
+                    default = '"{}",'.format(field.default)
+                    field_line += default
+                else:
+                    field_line += "NA,"
+                    
+             
+               
+                
+                #add this field line to the documentation
                 try:
                     #get the set of types this field was derived from
                     if isinstance(field, mm.fields.List):
@@ -52,7 +80,8 @@ def process_schemas(app, what, name, obj, options, lines):
                         base_types = inspect.getmro(type(field.container))
                     else:
                         base_types = inspect.getmro(type(field))
-                  
+            
+                
                     #use these base_types to figure out the raw_json type for this field
                     if isinstance(field,mm.fields.Nested):
                         #if it's a nested field we should specify it as a dict, and link to the documentation 
@@ -72,25 +101,10 @@ def process_schemas(app, what, name, obj, options, lines):
                             #if its not in the FIELD_TYPE_MAP, we aren't sure what type it is
                             #TODO handle this more elegantly/and/or patch up more use cases
                             raw_type = '?'
-                    field_line += "(:class:`{}.{}` : {}) ".format(type(field).__module__,type(field).__name__,raw_type)
+                    field_line += ":class:`{}.{}` : {}".format(type(field).__module__,type(field).__name__,raw_type)
                 except:
                     #in case this fails for some reason, note it as unknown
                     #TODO handle this more elegantly, identify and patch up such cases
-                    field_line += " (unknown) "
-
-                #get the description of this field and add it to documentation
-                description = get_description_from_field(field)
-                if description is not None:
-                    field_line+=description
-                else:
-                    #if there is no description note that
-                    field_line+="no description "
-                if field.required:
-                    #add a REQUIRED stamp to required fields
-                    field_line += " REQUIRED "
-                if field.default is not mm.missing:
-                    #add in the default value if there is one
-                    field_line += " (default = {})".format(field.default)
-                #add this field line to the documentation
+                    field_line += "unknown"
                 lines.append(field_line)
-            
+            #lines.append(table_line)

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -16,15 +16,15 @@ def process_schemas(app, what, name, obj, options, lines):
             #find where the schema_type is as a keyword argument
             schema_index = next(i for i,arg in enumerate(args) if arg=='schema_type')
             #use its default value to construct the string version of the classpath to the module
-            if defaults[schema_index-1] is not None:
-                def_schema = defaults[schema_index-1].__module__+'.'+defaults[schema_index-1].__name__
-            else:
-                def_schema = 'None'
-
+            def_schema = defaults[schema_index-1]
+            if def_schema is None:
+                def_schema = obj.schema_type
+            def_schema_name = def_schema.__module__+'.'+def_schema.__name__
+            
             #append to the documentation
             lines.append(".. note::")
             lines.append("  This class takes a ArgSchema as an input to parse inputs")
-            lines.append("  , with a default schema of type :class:`{}`".format(def_schema))
+            lines.append("  , with a default schema of type :class:`{}`".format(def_schema_name))
             lines.append("")
         if issubclass(obj,ArgSchema):
             #add a special note to ArgSchema's

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -19,8 +19,11 @@ def process_schemas(app, what, name, obj, options, lines):
             def_schema = defaults[schema_index-1]
             if def_schema is None:
                 def_schema = obj.default_schema
-            def_schema_name = def_schema.__module__+'.'+def_schema.__name__
-            
+            if def_schema is not None:
+                def_schema_name = def_schema.__module__+'.'+def_schema.__name__
+            else:
+                def_schema_name = 'None'
+                
             #append to the documentation
             lines.append(".. note::")
             lines.append("  This class takes a ArgSchema as an input to parse inputs")

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -31,7 +31,7 @@ def process_schemas(app, what, name, obj, options, lines):
             schema = obj()
             lines.append(".. note::")
             lines.append("")
-            lines.append("  keys:")
+            lines.append("  keys: (field_type \: raw_type) description")
 
             #loop over the declared fields for this schema
             for field_name, field in schema.declared_fields.items():

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -18,8 +18,9 @@ def process_schemas(app, what, name, obj, options, lines):
             #use its default value to construct the string version of the classpath to the module
             def_schema = defaults[schema_index-1].__module__+'.'+defaults[schema_index-1].__name__
             #append to the documentation
-            lines.append("   This class takes a ArgSchema as an input to parse inputs")
-            lines.append(", with a default schema of type :class:`{}`".format(def_schema))
+            lines.append(".. note::")
+            lines.append("  This class takes a ArgSchema as an input to parse inputs")
+            lines.append("  , with a default schema of type :class:`{}`".format(def_schema))
             lines.append("")
         if issubclass(obj,ArgSchema):
             #add a special note to ArgSchema's
@@ -28,13 +29,15 @@ def process_schemas(app, what, name, obj, options, lines):
         if issubclass(obj,mm.Schema):
             #but document all mm.Schema's
             schema = obj()
-            lines.append("Schema:")
+            lines.append(".. note::")
+            lines.append("")
+            lines.append("  keys:")
 
             #loop over the declared fields for this schema
             for field_name, field in schema.declared_fields.items():
                 #we will build up the documentation line for each field
                 #start declaring the key as field_name like a parameter
-                field_line = "  :%s: "%field_name
+                field_line = "    :%s: "%field_name
                 try:
                     #get the set of types this field was derived from
                     if isinstance(field, mm.fields.List):
@@ -47,7 +50,10 @@ def process_schemas(app, what, name, obj, options, lines):
                     if isinstance(field,mm.fields.Nested):
                         #if it's a nested field we should specify it as a dict, and link to the documentation 
                         #for that nested schema
-                        raw_type = 'dict(:class:`~{}`)'.format(type(field.schema).__name__)
+                        if field.many == True:
+                           raw_type = 'list[:class:`~{}`]'.format(type(field.schema).__name__)
+                        else:
+                           raw_type = 'dict(:class:`~{}`)'.format(type(field.schema).__name__)
                     else:
                         #otherwise we should be able to look it up in the FIELD_TYPE_MAP
                         try:

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -18,7 +18,7 @@ def process_schemas(app, what, name, obj, options, lines):
             #use its default value to construct the string version of the classpath to the module
             def_schema = defaults[schema_index-1]
             if def_schema is None:
-                def_schema = obj.schema_type
+                def_schema = obj.default_schema
             def_schema_name = def_schema.__module__+'.'+def_schema.__name__
             
             #append to the documentation

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -9,48 +9,73 @@ FIELD_TYPE_MAP = {v: k for k, v in mm.Schema.TYPE_MAPPING.items()}
 def process_schemas(app, what, name, obj, options, lines):
 
     if what == "class":
+        #pick out the ArgSchemaParser objects for documenting
         if issubclass(obj,ArgSchemaParser):
-            
+            #inspect the objects init function to find default schema
             (args,vargs,varkw,defaults)=inspect.getargspec(obj.__init__)
+            #find where the schema_type is as a keyword argument
             schema_index = next(i for i,arg in enumerate(args) if arg=='schema_type')
+            #use its default value to construct the string version of the classpath to the module
             def_schema = defaults[schema_index-1].__module__+'.'+defaults[schema_index-1].__name__
+            #append to the documentation
             lines.append("   This class takes a ArgSchema as an input to parse inputs")
             lines.append(", with a default schema of type :class:`{}`".format(def_schema))
             lines.append("")
         if issubclass(obj,ArgSchema):
+            #add a special note to ArgSchema's
             lines.append("   This schema is designed to be a schema_type for an ArgSchemaParser object")
             lines.append("")
         if issubclass(obj,mm.Schema):
+            #but document all mm.Schema's
             schema = obj()
             lines.append("Schema:")
+
+            #loop over the declared fields for this schema
             for field_name, field in schema.declared_fields.items():
-                
+                #we will build up the documentation line for each field
+                #start declaring the key as field_name like a parameter
                 field_line = "  :%s: "%field_name
                 try:
+                    #get the set of types this field was derived from
                     if isinstance(field, mm.fields.List):
+                        #if it's a list we want to do this for its container
                         base_types = inspect.getmro(type(field.container))
                     else:
                         base_types = inspect.getmro(type(field))
                   
+                    #use these base_types to figure out the raw_json type for this field
                     if isinstance(field,mm.fields.Nested):
+                        #if it's a nested field we should specify it as a dict, and link to the documentation 
+                        #for that nested schema
                         raw_type = 'dict(:class:`~{}`)'.format(type(field.schema).__name__)
                     else:
+                        #otherwise we should be able to look it up in the FIELD_TYPE_MAP
                         try:
                             base_type=next(bt for bt in base_types if bt in FIELD_TYPE_MAP)
                             raw_type=FIELD_TYPE_MAP[base_type].__name__
                         except:
+                            #if its not in the FIELD_TYPE_MAP, we aren't sure what type it is
+                            #TODO handle this more elegantly/and/or patch up more use cases
                             raw_type = '?'
                     field_line += "(:class:`{}.{}` : {}) ".format(type(field).__module__,type(field).__name__,raw_type)
                 except:
-                    field_line += "fail "
+                    #in case this fails for some reason, note it as unknown
+                    #TODO handle this more elegantly, identify and patch up such cases
+                    field_line += " (unknown) "
+
+                #get the description of this field and add it to documentation
                 description = get_description_from_field(field)
                 if description is not None:
                     field_line+=description
                 else:
+                    #if there is no description note that
                     field_line+="no description "
                 if field.required:
+                    #add a REQUIRED stamp to required fields
                     field_line += " REQUIRED "
                 if field.default is not mm.missing:
+                    #add in the default value if there is one
                     field_line += " (default = {})".format(field.default)
+                #add this field line to the documentation
                 lines.append(field_line)
             

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -16,7 +16,11 @@ def process_schemas(app, what, name, obj, options, lines):
             #find where the schema_type is as a keyword argument
             schema_index = next(i for i,arg in enumerate(args) if arg=='schema_type')
             #use its default value to construct the string version of the classpath to the module
-            def_schema = defaults[schema_index-1].__module__+'.'+defaults[schema_index-1].__name__
+            if defaults[schema_index-1] is not None:
+                def_schema = defaults[schema_index-1].__module__+'.'+defaults[schema_index-1].__name__
+            else:
+                def_schema = 'None'
+
             #append to the documentation
             lines.append(".. note::")
             lines.append("  This class takes a ArgSchema as an input to parse inputs")

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -23,11 +23,11 @@ def process_schemas(app, what, name, obj, options, lines):
                 def_schema_name = def_schema.__module__+'.'+def_schema.__name__
             else:
                 def_schema_name = 'None'
-                
+
             #append to the documentation
             lines.append(".. note::")
             lines.append("  This class takes a ArgSchema as an input to parse inputs")
-            lines.append("  , with a default schema of type :class:`{}`".format(def_schema_name))
+            lines.append("  , with a default schema of type :class:`~{}`".format(def_schema_name))
             lines.append("")
         if issubclass(obj,ArgSchema):
             #add a special note to ArgSchema's

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -10,10 +10,12 @@ def process_schemas(app, what, name, obj, options, lines):
 
     if what == "class":
         if issubclass(obj,ArgSchemaParser):
-            lines.append("   This class takes a ArgSchema as an input to parse inputs")
+            
             (args,vargs,varkw,defaults)=inspect.getargspec(obj.__init__)
-            def_schema = defaults[1].__module__+'.'+defaults[1].__name__
-            lines.append("   This class's default ArgSchema is of type :class:`{}`".format(def_schema))
+            schema_index = next(i for i,arg in enumerate(args) if arg=='schema_type')
+            def_schema = defaults[schema_index-1].__module__+'.'+defaults[schema_index-1].__name__
+            lines.append("   This class takes a ArgSchema as an input to parse inputs")
+            lines.append(", with a default schema of type :class:`{}`".format(def_schema))
             lines.append("")
         if issubclass(obj,ArgSchema):
             lines.append("   This schema is designed to be a schema_type for an ArgSchemaParser object")

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,5 @@
 sphinxcontrib-napoleon
 numpy
 marshmallow
+pytest
+argschema

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -2,4 +2,3 @@ sphinxcontrib-napoleon
 numpy
 marshmallow
 pytest
-argschema

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinxcontrib.napoleon'
 ]
@@ -287,6 +288,8 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+intersphinx_mapping = {'marshmallow':('http://marshmallow.readthedocs.io/en/latest/', None)}
 
 sys.path.insert(0, os.path.abspath("../"))   
 sys.path.insert(0, os.path.abspath("../test"))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,3 +287,11 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+import sys
+sys.path.insert(0, os.path.abspath("../"))   
+sys.path.insert(0, os.path.abspath("../test"))
+from argschema.autodoc import process_schemas
+
+def setup(app):
+    app.connect('autodoc-process-docstring',process_schemas)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -288,7 +288,6 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
-import sys
 sys.path.insert(0, os.path.abspath("../"))   
 sys.path.insert(0, os.path.abspath("../test"))
 from argschema.autodoc import process_schemas

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,17 @@ This contains the complete documentation of the api
 
    api/argschema
 
+TESTS
+-----
+
+This contains the tests
+
+.. toctree::
+   :maxdepth: 4
+
+   tests/modules
+   tests/fields
+
 
 Indices and tables
 ==================

--- a/docs/tests/fields.rst
+++ b/docs/tests/fields.rst
@@ -1,0 +1,54 @@
+fields package
+==============
+
+Submodules
+----------
+
+fields\.test\_deprecated module
+-------------------------------
+
+.. automodule:: fields.test_deprecated
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fields\.test\_files module
+--------------------------
+
+.. automodule:: fields.test_files
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fields\.test\_loglevel module
+-----------------------------
+
+.. automodule:: fields.test_loglevel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fields\.test\_numpyarray module
+-------------------------------
+
+.. automodule:: fields.test_numpyarray
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fields\.test\_slice module
+--------------------------
+
+.. automodule:: fields.test_slice
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fields
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/tests/modules.rst
+++ b/docs/tests/modules.rst
@@ -6,3 +6,4 @@ test
 
    test_first_test
    test_output
+   test_argschema_parser

--- a/docs/tests/modules.rst
+++ b/docs/tests/modules.rst
@@ -1,0 +1,8 @@
+test
+====
+
+.. toctree::
+   :maxdepth: 4
+
+   test_first_test
+   test_output

--- a/docs/tests/test_argschema_parser.rst
+++ b/docs/tests/test_argschema_parser.rst
@@ -1,0 +1,7 @@
+test\_argschema\_parser module
+==============================
+
+.. automodule:: test_argschema_parser
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/tests/test_first_test.rst
+++ b/docs/tests/test_first_test.rst
@@ -1,0 +1,7 @@
+test\_first\_test module
+========================
+
+.. automodule:: test_first_test
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/tests/test_output.rst
+++ b/docs/tests/test_output.rst
@@ -1,0 +1,7 @@
+test\_output module
+===================
+
+.. automodule:: test_output
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -139,6 +139,21 @@ so now if run the example commands found in run_template.sh
     $ python template_module.py
     {u'name': u'from_dictionary', u'inc_array': [5.0, 7.0, 10.0]}    
 
+Sphinx Documentation
+--------------------
+argschema comes with a autodocumentation feature for Sphnix which will help you automatically
+add documentation of your Schemas and ArgSchemaParser classes in your project. This is how the 
+documentation of the :doc:`../tests/modules` suite included here was generated.
+
+To configure sphnix to use this function, you must be using the sphnix autodoc module and add the following to your conf.py file
+
+.. code-block:: python
+
+    from argschema.autodoc import process_schemas
+
+    def setup(app):
+        app.connect('autodoc-process-docstring',process_schemas)
+
 Installation
 ------------
 install via source code

--- a/setup.py
+++ b/setup.py
@@ -17,3 +17,4 @@ setup(name='argschema',
       install_requires=required,
       setup_requires=['pytest-runner'],
       tests_require=test_required)
+

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('test_requirements.txt','r') as f:
     test_required = f.read().splitlines()
 
 setup(name='argschema',
-      version='1.14.5',
+      version='1.15.0',
       description=' a wrapper for setting up modules that can have parameters specified by command line arguments,\
        json_files, or dictionary objects. Providing a common wrapper for data processing modules.',
       author='Forrest Collman,David Feng',

--- a/test/fields/test_deprecated.py
+++ b/test/fields/test_deprecated.py
@@ -6,7 +6,7 @@ import marshmallow as mm
 
 
 class OptionSchema(ArgSchema):
-    a = OptionList([1, 2, 3], required=True, description='a slice object')
+    a = OptionList([1, 2, 3], required=True, description='one of 1,2,3')
 
 
 def test_option_list():

--- a/test/fields/test_numpyarray.py
+++ b/test/fields/test_numpyarray.py
@@ -13,7 +13,7 @@ numpy_array_test = {
 class NumpyFileuint16(ArgSchema):
     a = NumpyArray(
         dtype='uint16', required=True,
-        decription='list of lists representing numpy array')
+        description='list of lists representing a uint16 numpy array')
 
 
 def test_numpy():

--- a/test/test_argschema_parser.py
+++ b/test/test_argschema_parser.py
@@ -12,8 +12,7 @@ class MySchema(argschema.ArgSchema):
     nest = argschema.fields.Nested(MyNestedSchema,description="a nested schema")
 
 class MyParser(argschema.ArgSchemaParser):
-    def __init__(self,schema_type=MySchema,*args,**kwargs):
-        super(MyParser,self).__init__(schema_type=schema_type, *args, **kwargs)
+    default_schema = MySchema
 
 def test_my_parser():
     input_data = {

--- a/test/test_argschema_parser.py
+++ b/test/test_argschema_parser.py
@@ -1,0 +1,26 @@
+import argschema
+import pytest
+
+
+class MyNestedSchema(argschema.schemas.DefaultSchema):
+    one = argschema.fields.Int(required=True,description="nested integer")
+    two = argschema.fields.Boolean(required=True,description="a nested boolean")
+
+class MySchema(argschema.ArgSchema):
+    a = argschema.fields.Int(required=True,description="parameter a")
+    b = argschema.fields.Str(required=False,default="my value",description="optional b string parameter")
+    nest = argschema.fields.Nested(MyNestedSchema,description="a nested schema")
+
+class MyParser(argschema.ArgSchemaParser):
+    def __init__(self,schema_type=MySchema,*args,**kwargs):
+        super(MyParser,self).__init__(schema_type=schema_type, *args, **kwargs)
+
+def test_my_parser():
+    input_data = {
+        'a':5,
+        'nest':{
+            'one':7,
+            'two':False
+        }
+    }
+    mod = MyParser(input_data = input_data, args=[])

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -2,6 +2,7 @@ from argschema.autodoc import process_schemas
 import pytest
 from test_first_test import SimpleExtension,ExampleRecursiveSchema,RecursiveSchema,MyShorterExtension
 from fields.test_slice import SliceSchema
+from argschema.argschema_parser import ArgSchemaParser
 
 def test_autodoc():
     lines = []
@@ -34,3 +35,8 @@ def test_autodoc_list():
     list_field=next(line for line in lines if 'List' in line)
     assert('d' in list_field)
     assert('List` : int' in list_field)
+
+def test_autodoc_argschemaparser():
+    lines = []
+    process_schemas(None, 'class', 'ArgSchemaParser', ArgSchemaParser, None, lines)
+    assert('  This class takes a ArgSchema as an input to parse inputs' in lines)

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -1,0 +1,36 @@
+from argschema.autodoc import process_schemas
+import pytest
+from test_first_test import SimpleExtension,ExampleRecursiveSchema,RecursiveSchema,MyShorterExtension
+from fields.test_slice import SliceSchema
+
+def test_autodoc():
+    lines = []
+    process_schemas(None, 'class', 'SimpleExtension', SimpleExtension, None, lines)
+    assert('   This schema is designed to be a schema_type for an ArgSchemaParser object' in lines)
+    
+def test_autodoc_nested():
+    lines = []
+    process_schemas(None, 'class', 'ExampleRecursiveSchema', ExampleRecursiveSchema, None, lines)
+    nested_field=next(line for line in lines if 'Nested' in line)
+    assert('~RecursiveSchema' in nested_field)
+    assert('dict' in nested_field)
+
+def test_autodoc_slice():
+    lines = []
+    process_schemas(None, 'class', 'SliceSchema', SliceSchema, None, lines)
+    slice_field=next(line for line in lines if 'argschema.fields.slice.Slice' in line)
+    assert('?' in slice_field)
+
+def test_autodoc_recursive_nested():
+    lines = []
+    process_schemas(None, 'class', 'RecursiveSchema', RecursiveSchema, None, lines)
+    nested_field=next(line for line in lines if 'Nested' in line)
+    assert('~RecursiveSchema' in nested_field)
+    assert('list' in nested_field)
+    
+def test_autodoc_list():
+    lines=[]
+    process_schemas(None, 'class', 'MyShorterExtension', MyShorterExtension, None, lines)
+    list_field=next(line for line in lines if 'List' in line)
+    assert('d' in list_field)
+    assert('List` : int' in list_field)

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -3,6 +3,7 @@ import pytest
 from test_first_test import SimpleExtension,ExampleRecursiveSchema,RecursiveSchema,MyShorterExtension
 from fields.test_slice import SliceSchema
 from argschema.argschema_parser import ArgSchemaParser
+from test_argschema_parser import MyParser
 
 def test_autodoc():
     lines = []
@@ -40,3 +41,10 @@ def test_autodoc_argschemaparser():
     lines = []
     process_schemas(None, 'class', 'ArgSchemaParser', ArgSchemaParser, None, lines)
     assert('  This class takes a ArgSchema as an input to parse inputs' in lines)
+
+def test_autodoc_argschemaparser():
+    lines = []
+    process_schemas(None, 'class', 'MyParser', MyParser, None, lines)
+    assert('  This class takes a ArgSchema as an input to parse inputs' in lines)
+    default_line = next(line for line in lines if 'default schema of type' in line)
+    assert ':class:`test_argschema_parser.MySchema`' in default_line

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -14,7 +14,7 @@ def test_autodoc_nested():
     lines = []
     process_schemas(None, 'class', 'ExampleRecursiveSchema', ExampleRecursiveSchema, None, lines)
     nested_field=next(line for line in lines if 'Nested' in line)
-    assert('~RecursiveSchema' in nested_field)
+    assert('RecursiveSchema' in nested_field)
     assert('dict' in nested_field)
 
 def test_autodoc_slice():
@@ -27,7 +27,7 @@ def test_autodoc_recursive_nested():
     lines = []
     process_schemas(None, 'class', 'RecursiveSchema', RecursiveSchema, None, lines)
     nested_field=next(line for line in lines if 'Nested' in line)
-    assert('~RecursiveSchema' in nested_field)
+    assert('RecursiveSchema' in nested_field)
     assert('list' in nested_field)
     
 def test_autodoc_list():

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -47,4 +47,4 @@ def test_autodoc_myparser():
     process_schemas(None, 'class', 'MyParser', MyParser, None, lines)
     assert('  This class takes a ArgSchema as an input to parse inputs' in lines)
     default_line = next(line for line in lines if 'default schema of type' in line)
-    assert ':class:`test_argschema_parser.MySchema`' in default_line
+    assert ':class:`~test_argschema_parser.MySchema`' in default_line

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -42,7 +42,7 @@ def test_autodoc_argschemaparser():
     process_schemas(None, 'class', 'ArgSchemaParser', ArgSchemaParser, None, lines)
     assert('  This class takes a ArgSchema as an input to parse inputs' in lines)
 
-def test_autodoc_argschemaparser():
+def test_autodoc_myparser():
     lines = []
     process_schemas(None, 'class', 'MyParser', MyParser, None, lines)
     assert('  This class takes a ArgSchema as an input to parse inputs' in lines)

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -13,8 +13,7 @@ def test_autodoc():
 def test_autodoc_nested():
     lines = []
     process_schemas(None, 'class', 'ExampleRecursiveSchema', ExampleRecursiveSchema, None, lines)
-    nested_field=next(line for line in lines if 'Nested' in line)
-    assert('RecursiveSchema' in nested_field)
+    nested_field=next(line for line in lines if 'RecursiveSchema`' in line)
     assert('dict' in nested_field)
 
 def test_autodoc_slice():
@@ -26,16 +25,14 @@ def test_autodoc_slice():
 def test_autodoc_recursive_nested():
     lines = []
     process_schemas(None, 'class', 'RecursiveSchema', RecursiveSchema, None, lines)
-    nested_field=next(line for line in lines if 'Nested' in line)
-    assert('RecursiveSchema' in nested_field)
+    nested_field=next(line for line in lines if 'RecursiveSchema`,' in line)
     assert('list' in nested_field)
     
 def test_autodoc_list():
     lines=[]
     process_schemas(None, 'class', 'MyShorterExtension', MyShorterExtension, None, lines)
     list_field=next(line for line in lines if 'List' in line)
-    assert('d' in list_field)
-    assert('List` : int' in list_field)
+    assert('int' in list_field)
 
 def test_autodoc_argschemaparser():
     lines = []


### PR DESCRIPTION
This implements an autodocumentation feature for sphnix.

see for example the documentation of tests now included in this branch.
http://argschema.readthedocs.io/en/autodoc/tests/test_argschema_parser.html#test_argschema_parser.MyParser

I have used this successfully to enable automated documentation for render-modules (at least to the level that you get from the descriptions).  By using intersphinx you can also get modules that use argschema to link their field definitions back to the argschema field definition,which will contain more clarity as to what those fields need to be.

feedback welcome, but i'm pretty jazzed about this conceptually.