### PR TITLE
Autodoc refinement

### DIFF
--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -6,87 +6,83 @@ import inspect
 
 FIELD_TYPE_MAP = {v: k for k, v in mm.Schema.TYPE_MAPPING.items()}
 
+
 def process_schemas(app, what, name, obj, options, lines):
 
     if what == "class":
-        #pick out the ArgSchemaParser objects for documenting
-        if issubclass(obj,ArgSchemaParser):
-            #inspect the objects init function to find default schema
-            (args,vargs,varkw,defaults)=inspect.getargspec(obj.__init__)
-            #find where the schema_type is as a keyword argument
-            schema_index = next(i for i,arg in enumerate(args) if arg=='schema_type')
-            #use its default value to construct the string version of the classpath to the module
-            def_schema = defaults[schema_index-1]
-            
+        # pick out the ArgSchemaParser objects for documenting
+        if issubclass(obj, ArgSchemaParser):
+            # inspect the objects init function to find default schema
+            (args, vargs, varkw, defaults) = inspect.getargspec(obj.__init__)
+            # find where the schema_type is as a keyword argument
+            schema_index = next(i for i, arg in enumerate(
+                args) if arg == 'schema_type')
+            # use its default value to construct the string version of the classpath to the module
+            def_schema = defaults[schema_index - 1]
+
             def_schema = def_schema or obj.default_schema
             if def_schema is not None:
-                def_schema_name = def_schema.__module__+'.'+def_schema.__name__
+                def_schema_name = def_schema.__module__ + '.' + def_schema.__name__
             def_schema_name = def_schema_name or 'None'
 
-            #append to the documentation
+            # append to the documentation
             lines.append(".. note::")
-            lines.append("  This class takes a ArgSchema as an input to parse inputs")
-            lines.append("  , with a default schema of type :class:`~{}`".format(def_schema_name))
+            lines.append(
+                "  This class takes a ArgSchema as an input to parse inputs")
+            lines.append(
+                "  , with a default schema of type :class:`~{}`".format(def_schema_name))
             lines.append("")
-        if issubclass(obj,ArgSchema):
-            #add a special note to ArgSchema's
-            lines.append("   This schema is designed to be a schema_type for an ArgSchemaParser object")
+        if issubclass(obj, ArgSchema):
+            # add a special note to ArgSchema's
+            lines.append(
+                "   This schema is designed to be a schema_type for an ArgSchemaParser object")
             lines.append("")
-        if issubclass(obj,mm.Schema):
-            #but document all mm.Schema's
+        if issubclass(obj, mm.Schema):
+            # but document all mm.Schema's
             schema = obj()
-            #lines.append(".. note::")
-            #lines.append("")
-            #lines.append("  keys: (field_type \: raw_type) description")
-
-            if len(schema.declared_fields)>0:
-                lines.append(".. csv-table:: %s"%obj.__name__)
-                lines.append('   :header: "key", "description", "default","field_type","json_type"')
+            if len(schema.declared_fields) > 0:
+                lines.append(".. csv-table:: %s" % obj.__name__)
+                lines.append(
+                    '   :header: "key", "description", "default","field_type","json_type"')
                 lines.append('   :widths: 30, 80, 30, 30, 30')
                 lines.append('')
-                
 
                 # #loop over the declared fields for this schema
                 for field_name, field in schema.declared_fields.items():
-                    #we will build up the documentation line for each field
-                    #start declaring the key as field_name like a parameter
-                    field_line = "    %s,"%field_name
-                
-                    #get the description of this field and add it to documentation
-                    description = get_description_from_field(field)
-                    
-                    description = description or "no description" 
-                    description=description.replace('\"',"'")        
-                    field_line+='"%s",'%description
-        
+                    # we will build up the documentation line for each field
+                    # start declaring the key as field_name like a parameter
+                    field_line = "    %s," % field_name
 
-                    #if field.required:
-                    #    #add a REQUIRED stamp to required fields
-                    #    field_line += " REQUIRED "
+                    # get the description of this field and add it to documentation
+                    description = get_description_from_field(field)
+
+                    description = description or "no description"
+                    description = description.replace('\"', "'")
+                    field_line += '"%s",' % description
+
                     if field.default is not mm.missing:
-                        #add in the default value if there is one
+                        # add in the default value if there is one
                         default = '"{}",'.format(field.default)
                         field_line += default
+                    elif field.required:
+                        field_line += '(REQUIRED),'
                     else:
                         field_line += "NA,"
-                        
-                
-                
-                    
-                    #add this field line to the documentation
+
+                    # add this field line to the documentation
                     try:
-                        #get the set of types this field was derived from
+                        # get the set of types this field was derived from
                         if isinstance(field, mm.fields.List):
-                            #if it's a list we want to do this for its container
+                            # if it's a list we want to do this for its container
                             base_types = inspect.getmro(type(field.container))
                         else:
                             base_types = inspect.getmro(type(field))
-                
+
                         field_type = type(field)
-                        #use these base_types to figure out the raw_json type for this field
-                        if isinstance(field,mm.fields.Nested):
-                            #if it's a nested field we should specify it as a dict, and link to the documentation 
-                            #for that nested schema
+                        # use these base_types to figure out the raw_json type for this field
+                        if isinstance(field, mm.fields.Nested):
+                            # if it's a nested field we should specify it as a dict, and link to the documentation
+                            # for that nested schema
                             # = type
                             #schema_type = type(field.schema)
                             field_type = type(field.schema)
@@ -96,21 +92,23 @@ def process_schemas(app, what, name, obj, options, lines):
                             else:
                                 raw_type = 'dict'
                         else:
-                            #otherwise we should be able to look it up in the FIELD_TYPE_MAP
+                            # otherwise we should be able to look it up in the FIELD_TYPE_MAP
                             try:
-                                base_type=next(bt for bt in base_types if bt in FIELD_TYPE_MAP)
-                                raw_type=FIELD_TYPE_MAP[base_type].__name__
-                                #hack in marshmallow for py3 which things Str is type 'bytes'
+                                base_type = next(
+                                    bt for bt in base_types if bt in FIELD_TYPE_MAP)
+                                raw_type = FIELD_TYPE_MAP[base_type].__name__
+                                # hack in marshmallow for py3 which things Str is type 'bytes'
                                 if raw_type == 'bytes':
                                     raw_type = 'str'
                             except:
-                                #if its not in the FIELD_TYPE_MAP, we aren't sure what type it is
-                                #TODO handle this more elegantly/and/or patch up more use cases
+                                # if its not in the FIELD_TYPE_MAP, we aren't sure what type it is
+                                # TODO handle this more elegantly/and/or patch up more use cases
                                 raw_type = '?'
-                        field_line += ":class:`~{}.{}`,{}".format(field_type.__module__,field_type.__name__,raw_type)
+                        field_line += ":class:`~{}.{}`,{}".format(
+                            field_type.__module__, field_type.__name__, raw_type)
                     except:
-                        #in case this fails for some reason, note it as unknown
-                        #TODO handle this more elegantly, identify and patch up such cases
+                        # in case this fails for some reason, note it as unknown
+                        # TODO handle this more elegantly, identify and patch up such cases
                         field_line += "unknown,unknown"
                     lines.append(field_line)
-                #lines.append(table_line)
+                # lines.append(table_line)

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -17,12 +17,11 @@ def process_schemas(app, what, name, obj, options, lines):
             schema_index = next(i for i,arg in enumerate(args) if arg=='schema_type')
             #use its default value to construct the string version of the classpath to the module
             def_schema = defaults[schema_index-1]
-            if def_schema is None:
-                def_schema = obj.default_schema
+            
+            def_schema = def_schema or obj.default_schema
             if def_schema is not None:
                 def_schema_name = def_schema.__module__+'.'+def_schema.__name__
-            else:
-                def_schema_name = 'None'
+            def_schema_name = def_schema_name or 'None'
 
             #append to the documentation
             lines.append(".. note::")
@@ -56,8 +55,7 @@ def process_schemas(app, what, name, obj, options, lines):
                     #get the description of this field and add it to documentation
                     description = get_description_from_field(field)
                     
-                    if description is None:
-                        description="no description" 
+                    description = description or "no description" 
                     description=description.replace('\"',"'")        
                     field_line+='"%s",'%description
         

--- a/docs/tests/modules.rst
+++ b/docs/tests/modules.rst
@@ -7,3 +7,5 @@ test
    test_first_test
    test_output
    test_argschema_parser
+   test_utils
+   test_autodoc

--- a/docs/tests/test_autodoc.rst
+++ b/docs/tests/test_autodoc.rst
@@ -1,0 +1,7 @@
+test\_autodoc module
+====================
+
+.. automodule:: test_autodoc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/tests/test_utils.rst
+++ b/docs/tests/test_utils.rst
@@ -1,0 +1,7 @@
+test\_utils module
+==================
+
+.. automodule:: test_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -5,40 +5,72 @@ from fields.test_slice import SliceSchema
 from argschema.argschema_parser import ArgSchemaParser
 import argschema
 from test_argschema_parser import MyParser
+import rstcheck
+import docutils.utils
+
+def validate_rst_lines(lines,level = docutils.utils.Reporter.WARNING_LEVEL):
+    """validates a set of lines that would make up an rst file
+    using rstcheck
+    
+    Parameters
+    ==========
+    lines: list[str]
+        a list of lines that would compose some restructuredText
+    level: docutils.utils.Reporter.WARNING_LEVEL
+        the reporting level to hold this to
+    Returns
+    =======
+    None
+
+    Raises
+    ======
+    AssertionError
+        If the lines contain any errors above the  level
+    """
+    long_string  = "\n".join(lines)
+    results = list(rstcheck.check(long_string, report_level = level))
+    print(results)
+    assert(len(results)==0)
 
 def test_autodoc():
     lines = []
     process_schemas(None, 'class', 'SimpleExtension', SimpleExtension, None, lines)
     assert('   This schema is designed to be a schema_type for an ArgSchemaParser object' in lines)
-    
+    validate_rst_lines(lines)
+
 def test_autodoc_nested():
     lines = []
     process_schemas(None, 'class', 'ExampleRecursiveSchema', ExampleRecursiveSchema, None, lines)
     nested_field=next(line for line in lines if 'RecursiveSchema`' in line)
     assert('dict' in nested_field)
-
+    validate_rst_lines(lines)
+    
 def test_autodoc_slice():
     lines = []
     process_schemas(None, 'class', 'SliceSchema', SliceSchema, None, lines)
     slice_field=next(line for line in lines if 'argschema.fields.slice.Slice' in line)
-    assert('str' in slice_field)
+    assert(('unicode' in slice_field) or ('str' in slice_field))
+    validate_rst_lines(lines)
 
 def test_autodoc_recursive_nested():
     lines = []
     process_schemas(None, 'class', 'RecursiveSchema', RecursiveSchema, None, lines)
     nested_field=next(line for line in lines if 'RecursiveSchema`,' in line)
     assert('list' in nested_field)
+    validate_rst_lines(lines)
     
 def test_autodoc_list():
     lines=[]
     process_schemas(None, 'class', 'MyShorterExtension', MyShorterExtension, None, lines)
     list_field=next(line for line in lines if 'List' in line)
     assert('int' in list_field)
+    validate_rst_lines(lines)
 
 def test_autodoc_argschemaparser():
     lines = []
     process_schemas(None, 'class', 'ArgSchemaParser', ArgSchemaParser, None, lines)
     assert('  This class takes a ArgSchema as an input to parse inputs' in lines)
+    validate_rst_lines(lines)
 
 def test_autodoc_myparser():
     lines = []
@@ -46,13 +78,12 @@ def test_autodoc_myparser():
     assert('  This class takes a ArgSchema as an input to parse inputs' in lines)
     default_line = next(line for line in lines if 'default schema of type' in line)
     assert ':class:`~test_argschema_parser.MySchema`' in default_line
+    validate_rst_lines(lines)
 
 class SchemaWithQuotedDescriptions(argschema.ArgSchema):
     a = argschema.fields.Int(required=True, description='something that is "quoted" is problematic')
 
 def test_autodoc_quotes():
-    input_data = {
-        'a':5
-    }
-    mod = argschema.ArgSchemaParser(input_data = input_data,
-                                    schema_type=SchemaWithQuotedDescriptions)
+    lines = []
+    process_schemas(None,'class','SchemaWithQuotedDescriptions',SchemaWithQuotedDescriptions,None,lines)
+    validate_rst_lines(lines)

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -3,6 +3,7 @@ import pytest
 from test_first_test import SimpleExtension,ExampleRecursiveSchema,RecursiveSchema,MyShorterExtension
 from fields.test_slice import SliceSchema
 from argschema.argschema_parser import ArgSchemaParser
+import argschema
 from test_argschema_parser import MyParser
 
 def test_autodoc():
@@ -45,3 +46,10 @@ def test_autodoc_myparser():
     assert('  This class takes a ArgSchema as an input to parse inputs' in lines)
     default_line = next(line for line in lines if 'default schema of type' in line)
     assert ':class:`~test_argschema_parser.MySchema`' in default_line
+
+class SchemaWithQuotedDescriptions(argschema.ArgSchema):
+    a = argschema.fields.Int(required=True, description='something that is "quoted" is problematic')
+
+def test_autodoc_quotes():
+    mod = argschema.ArgSchemaParser(schema_type=SchemaWithQuotedDescriptions)
+    

--- a/test/test_autodoc.py
+++ b/test/test_autodoc.py
@@ -51,5 +51,8 @@ class SchemaWithQuotedDescriptions(argschema.ArgSchema):
     a = argschema.fields.Int(required=True, description='something that is "quoted" is problematic')
 
 def test_autodoc_quotes():
-    mod = argschema.ArgSchemaParser(schema_type=SchemaWithQuotedDescriptions)
-    
+    input_data = {
+        'a':5
+    }
+    mod = argschema.ArgSchemaParser(input_data = input_data,
+                                    schema_type=SchemaWithQuotedDescriptions)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,3 +7,5 @@ pytest-pep8>=1.0.6
 pytest-xdist>=1.14
 pylint>=1.5.4
 flake8>=3.0.4
+rstcheck
+sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+
 [tox]
 envlist = py27, py36
 
 [testenv]
 commands = pytest
-deps =
-    -rrequirements.txt
-    -rtest_requirements.txt
+deps =  -rrequirements.txt
+        -rtest_requirements.txt


### PR DESCRIPTION
I noticed in render-modules that double quotes were not working in descriptions due to the csv-tables way i did things.. i have now replaced them with single quotes in the documentation