### PR TITLE
Increment version on dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,13 @@ jobs:
     steps:
       - checkout
       - run:
+          name: increment version
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            python setup.py install
+            python .circleci/increment_version.py
+      - run:
           name: merge with master
           command: |
             .circleci/circle_master_merge.sh
@@ -48,13 +55,6 @@ jobs:
           - python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
           # fallback to using the latest cache if no exact match is found
           - python3-dependencies-
-      - run:
-          name: increment version
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            python setup.py install
-            python .circleci/increment_version.py
       - run:
           name: package for pypi
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             python setup.py install
             python .circleci/increment_version.py
       - run:
-          name: merge with master
+          name: merge develop into master
           command: |
             .circleci/circle_master_merge.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,11 @@ jobs:
       - image: circleci/python:3.6.1
     steps:
       - checkout
+      - restore_cache:
+          keys:
+          - python3-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt"}}
+          # fallback to using the latest cache if no exact match is found
+          - python3-dependencies-
       - run:
           name: increment version
           command: |


### PR DESCRIPTION
This is a simple PR that changes the way the automatic version incremention on circleci works... now the version will be bumped in develop after it passes tests before it is merged with master.  This way develop will always have the most recent version number in its setup.py file, and merge conflicts won't appear when people increment the minor or major version numbers when it seems appropriate, and the CI will increment only the least significant version number. 