### PR TITLE
added optional output argument to allow user to specify location 

### DIFF
--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -180,20 +180,23 @@ class ArgSchemaParser(object):
         self.logger = self.initialize_logger(
             logger_name, self.args.get('log_level'))
 
-    def output(self,d):
+    def output(self,d,output_path=None):
         """method for outputing dictionary to the output_json file path after
         validating it through the output_schema_type
 
         Parameters
         ----------
         d:dict
-            output dictionary to output to self.mod['output_json'] location
-        
+            output dictionary to output 
+        output_path: str
+            path to save to output file, optional (with default to self.mod['output_json'] location)
         Raises
         ------
         marshmallow.ValidationError
             If any of the output dictionary doesn't meet the output schema
         """
+        if output_path is None:
+            output_path = self.args['output_json']
         if self.output_schema_type is not None:
             schema = self.output_schema_type()
             (output_json,errors)=schema.dump(d)
@@ -204,7 +207,7 @@ class ArgSchemaParser(object):
                                  the output won't be validated")
             output_json = d
 
-        with open(self.args['output_json'],'w') as fp:
+        with open(output_path,'w') as fp:
             json.dump(output_json,fp)
 
     def load_schema_with_defaults(self  ,schema, args):

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -70,3 +70,28 @@ def test_bad_output(tmpdir):
 
     with pytest.raises(mm.ValidationError):
         mod.output(output)
+
+def test_alt_output(tmpdir):
+    file_out = tmpdir.join('test_output.json')
+    file_out_2 = tmpdir.join('test_output_2.json')
+    input_parameters = {
+        'output_json':str(file_out)
+    }
+    mod = ArgSchemaParser(input_data = input_parameters,
+                          output_schema_type = MyOutputSchema,
+                          args=[])
+    M=[[5,5],[7,2]]
+    Mnp = np.array(M)
+    output = {
+        "a":"example",
+        "M":Mnp  
+    }
+    expected_output = {
+        "a":"example",
+        "b":5,
+        "M":M
+    }
+    mod.output(output,str(file_out_2))
+    with open(str(file_out_2),'r') as fp:
+        actual_output = json.load(fp)
+    assert actual_output == expected_output


### PR DESCRIPTION
I would like to use this feature to write out multiple output files each of which is validated against the output schema, but to different locations. 