### PR TITLE
fixed outpath to work on nfs and not leave temp files lying around

### DIFF
--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -7,8 +7,9 @@ import errno
 
 def validate_outpath(path):
     try:
-        with tempfile.TemporaryFile(mode='w', dir=path) as tfile:
+        with tempfile.NamedTemporaryFile(mode='w', dir=path) as tfile:
             tfile.write('0')
+            tfile.close()
     except Exception as e:
         if isinstance(e, OSError):
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
I don't know how to write a test for this, as I only see this behavior on nfs mounted drives.