### PR TITLE
Outdir fix

### DIFF
--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -7,8 +7,10 @@ import errno
 
 def validate_outpath(path):
     try:
-        with tempfile.TemporaryFile(mode='w', dir=path) as tfile:
+        with tempfile.NamedTemporaryFile(mode='w', dir=path) as tfile:
             tfile.write('0')
+            tfile.close()
+            
     except Exception as e:
         if isinstance(e, OSError):
             if e.errno == errno.ENOENT:

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -5,6 +5,7 @@ import json
 import numpy as np
 import pytest
 import marshmallow as mm
+import os
 
 class MyOutputSchema(DefaultSchema):
     a = Str(required=True, description="a simple string")
@@ -95,3 +96,14 @@ def test_alt_output(tmpdir):
     with open(str(file_out_2),'r') as fp:
         actual_output = json.load(fp)
     assert actual_output == expected_output
+
+def test_tmp_output_cleanput(tmpdir):
+    file_out = tmpdir.join('test_output.json')
+    input_parameters = {
+        'output_json':str(file_out)
+    }
+    mod = ArgSchemaParser(input_data = input_parameters,
+                          output_schema_type = MyOutputSchema,
+                          args=[])
+    files = os.listdir(str(tmpdir))
+    assert len(files)==0


### PR DESCRIPTION
this makes OutputDir and OutputFile work correctly on nfs mounts, which were having problems.  I don't know how to write a test for this.  I wrote a test that checks that the tmp files were removed after parsing the input, but I don't think that was a problem either except for on NFS mounts.