### PR TITLE
Fix star imports

### DIFF
--- a/argschema/fields/__init__.py
+++ b/argschema/fields/__init__.py
@@ -1,11 +1,15 @@
 '''sub-module for custom marshmallow fields of general utility'''
 from marshmallow.fields import *
-from marshmallow.fields import __all__
+from marshmallow.fields import __all__ as __mmall__
 from .files import OutputFile, InputDir, InputFile, OutputDir
 from .numpyarrays import NumpyArray
 from .deprecated import OptionList
 from .loglevel import LogLevel
 from .slice import Slice
 
-__all__ += ['OutputFile', 'InputDir', 'InputFile', 'OutputDir',
-            'NumpyArray', 'OptionList','LogLevel', 'Slice']
+__all__ = __mmall__ + ['OutputFile', 'InputDir', 'InputFile', 'OutputDir',
+                       'NumpyArray', 'OptionList','LogLevel', 'Slice']
+
+# Python 2 subpackage (not module) * imports break if items in __all__
+# are unicode.
+__all__ = list(map(str, __all__))

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -1,5 +1,5 @@
 from argschema import validate, ArgSchemaParser, ArgSchema
-from argschema.fields import NumpyArray
+from argschema.fields import *
 import pytest
 import marshmallow as mm
 import numpy as np

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -1,5 +1,6 @@
 from argschema import validate, ArgSchemaParser, ArgSchema
 from argschema.fields import *
+from marshmallow.fields import *
 import pytest
 import marshmallow as mm
 import numpy as np


### PR DESCRIPTION
argschema.fields defines __all__, suggesting that `from argschema.fields import *` is supported. This is broken in python 2.7 because marshmallow's __all__ is made up of unicode literals which throws an error for package imports in 2.7. This pull request fixes `from argschema.fields import *` on python 2.7, as well as fixes another issue where appending to __all__ causes any later attempts of `from marshmallow.fields import *` to throw an error.