### PR TITLE
Fixed nested no defaults

### DIFF
--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -151,13 +151,13 @@ class ArgSchemaParser(object):
 
         self.schema = schema_type()
         self.logger = self.initialize_logger(logger_name,'WARNING')
-        self.logger.warning('input_data is {}'.format(input_data))
+        self.logger.debug('input_data is {}'.format(input_data))
 
         # convert schema to argparse object
         p = utils.schema_argparser(self.schema)
         argsobj = p.parse_args(args)
         argsdict = utils.args_to_dict(argsobj)
-        self.logger.warning('argsdict is {}'.format(argsdict))
+        self.logger.debug('argsdict is {}'.format(argsdict))
 
         if argsobj.input_json is not None:
             result = self.schema.load(argsdict)
@@ -171,7 +171,7 @@ class ArgSchemaParser(object):
         
         # merge the command line dictionary into the input json
         args = utils.smart_merge(jsonargs, argsdict)
-        self.logger.warning('args after merge {}'.format(args))
+        self.logger.debug('args after merge {}'.format(args))
 
         # validate with load!
         result = self.load_schema_with_defaults(self.schema, args)

--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -150,11 +150,14 @@ class ArgSchemaParser(object):
             output_schema_type = self.default_output_schema
 
         self.schema = schema_type()
+        self.logger = self.initialize_logger(logger_name,'WARNING')
+        self.logger.warning('input_data is {}'.format(input_data))
 
         # convert schema to argparse object
         p = utils.schema_argparser(self.schema)
         argsobj = p.parse_args(args)
         argsdict = utils.args_to_dict(argsobj)
+        self.logger.warning('argsdict is {}'.format(argsdict))
 
         if argsobj.input_json is not None:
             result = self.schema.load(argsdict)
@@ -165,9 +168,10 @@ class ArgSchemaParser(object):
         else:
             jsonargs = input_data if input_data else {}
 
-        self.logger = self.initialize_logger(logger_name,'WARNING')
+        
         # merge the command line dictionary into the input json
         args = utils.smart_merge(jsonargs, argsdict)
+        self.logger.warning('args after merge {}'.format(args))
 
         # validate with load!
         result = self.load_schema_with_defaults(self.schema, args)

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -124,8 +124,12 @@ def smart_merge(a, b, path=None, merge_keys=None, overwrite_with_none=False):
                 if overwrite_with_none:
                     a[key] = b[key]
             else:
-                # otherwise replace entire leaf with b
-                a[key] = b[key]
+                if isinstance(b[key],dict):
+                    a[key]={}
+                    smart_merge(a[key], b[key], path + [str(key)], merge_keys)
+                else:
+                    # otherwise replace entire leaf with b
+                    a[key] = b[key]
     return a
 
 def get_description_from_field(field):

--- a/test/test_argschema_parser.py
+++ b/test/test_argschema_parser.py
@@ -23,3 +23,24 @@ def test_my_parser():
         }
     }
     mod = MyParser(input_data = input_data, args=[])
+
+class MyNestedSchemaWithDefaults(argschema.schemas.DefaultSchema):
+    one = argschema.fields.Int(default=1,
+        description="nested integer")
+    two = argschema.fields.Boolean(default=True,
+        description="a nested boolean")
+
+class MySchema2(argschema.ArgSchema):
+    a = argschema.fields.Int(required=True,description="parameter a")
+    b = argschema.fields.Str(required=False,default="my value",description="optional b string parameter")
+    nest = argschema.fields.Nested(MyNestedSchemaWithDefaults,description="a nested schema")
+
+
+
+def test_my_default_nested_parser():
+    input_data = {
+        'a':5
+    }
+    mod = argschema.ArgSchemaParser(input_data = input_data, 
+                                    schema_type=MySchema2,
+                                    args=None)

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -38,7 +38,7 @@ def test_log_catch():
 
 
 class MyExtension(argschema.schemas.DefaultSchema):
-    a = mm.fields.Str(description= 'a string')
+    a = mm.fields.Str(description= 'a string',required=True)
     b = mm.fields.Int(description= 'an integer')
     c = mm.fields.Int(description= 'an integer', default=10)
     d = mm.fields.List(mm.fields.Int,
@@ -46,7 +46,7 @@ class MyExtension(argschema.schemas.DefaultSchema):
 
 
 class SimpleExtension(ArgSchema):
-    test = mm.fields.Nested(MyExtension, default=None, required=True)
+    test = mm.fields.Nested(MyExtension, required=True)
 
 
 


### PR DESCRIPTION
Jed discovered a problem where he was not getting defaults filled in properly when he didn't pass in something by either input_json/dictionary or command line.  we wrote a test to reproduce the problem and figured out that a small change to test merge will solve the problem.  This also revealed that one of the tests was sort of stupid, with a nested schema which was required, but had a default, but none of its keys were required.  I  made one required to make the tests pass again. 