### PR TITLE
Resolves #62

### DIFF
--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -142,6 +142,7 @@ class ArgSchemaParser(object):
                  schema_type=None,  # schema for parsing arguments
                  output_schema_type = None, # schema for parsing output_json
                  args=None,
+                 parser=None,
                  logger_name=__name__):
         
         if schema_type is None:
@@ -154,7 +155,7 @@ class ArgSchemaParser(object):
         self.logger.debug('input_data is {}'.format(input_data))
 
         # convert schema to argparse object
-        p = utils.schema_argparser(self.schema)
+        p = utils.schema_argparser(self.schema, parser=parser)
         argsobj = p.parse_args(args)
         argsdict = utils.args_to_dict(argsobj)
         self.logger.debug('argsdict is {}'.format(argsdict))

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -264,7 +264,7 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
     return arguments
 
 
-def schema_argparser(schema):
+def schema_argparser(schema, parser=None):
     """given a jsonschema, build an argparse.ArgumentParser
 
     Parameters
@@ -286,7 +286,8 @@ def schema_argparser(schema):
     #make the root schema appeear first rather than last
     arguments = [arguments[-1]]+arguments[0:-1]
 
-    parser = argparse.ArgumentParser()
+    if parser == None:
+        parser = argparse.ArgumentParser()
 
     for arg_group in arguments:
         group=parser.add_argument_group(arg_group['title'],arg_group['description'])


### PR DESCRIPTION
This allows me to inject a custom parser:

```
    parser = argparse.ArgumentParser()
    parser.add_argument('--version', action='version', version=__version__)

    """Main entry point for running pyproject_template."""
    mod = ArgSchemaParser(schema_type=InputParameters,
                          output_schema_type=OutputParameters,
                          parser=parser)
```

This results in:

```
➜ git:(74) ✗ [nicholasc@nicholasc-ubuntu]~/projects/aibs.pyproject_template/$aibs.pyproject_template --version
0.1.0
➜ git:(74) ✗ [nicholasc@nicholasc-ubuntu]~/projects/aibs.pyproject_template/$aibs.pyproject_template -h       
usage: aibs.pyproject_template [-h] [--version] [--output_json OUTPUT_JSON]
                               [--input_json INPUT_JSON]
                               [--log_level LOG_LEVEL]

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit

InputParameters:
  --output_json OUTPUT_JSON
                        file path to output json file
  --input_json INPUT_JSON
                        file path of input json file
  --log_level LOG_LEVEL
                        set the logging level of the module (default=ERROR)
```

All tox envs passing on my dev environment