### PR TITLE
Fix boolean command line evaluation

### DIFF
--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -2,6 +2,7 @@
 marshmallow schemas to argparse and merging dictionaries from both systems
 '''
 import logging
+import ast
 import argparse
 from operator import add
 import inspect
@@ -228,9 +229,11 @@ def build_schema_arguments(schema, arguments=None, path=None, description =None)
                 if isinstance(validator,mm.validate.OneOf):
                     arg['help']+= " (valid options are {})".format(validator.choices)
 
-            #catch lists to figure out desired type
             field_type = type(field)
-            if isinstance(field, mm.fields.List):
+            if isinstance(field, mm.fields.Boolean):
+                arg['type'] = ast.literal_eval
+            #catch lists to figure out desired type
+            elif isinstance(field, mm.fields.List):
                 arg['nargs'] = '*'
                 container_type = type(field.container)
 

--- a/test/test_argschema_parser.py
+++ b/test/test_argschema_parser.py
@@ -36,7 +36,6 @@ class MySchema2(argschema.ArgSchema):
     nest = argschema.fields.Nested(MyNestedSchemaWithDefaults,description="a nested schema")
 
 
-
 def test_my_default_nested_parser():
     input_data = {
         'a':5
@@ -44,3 +43,24 @@ def test_my_default_nested_parser():
     mod = argschema.ArgSchemaParser(input_data = input_data, 
                                     schema_type=MySchema2,
                                     args=None)
+
+
+def test_boolean_command_line():
+    input_data = {
+        'a':5,
+        'nest':{
+            'one':7,
+            'two':True
+        }
+    }
+    mod = MyParser(input_data = input_data, args=["--nest.two", "False"])
+    assert(not mod.args['nest']['two'])
+    mod = MyParser(input_data = input_data, args=["--nest.two", "0"])
+    assert(not mod.args['nest']['two'])
+    input_data["nest"]["two"] = False
+    mod = MyParser(input_data = input_data, args=["--nest.two", "True"])
+    assert(mod.args['nest']['two'])
+    mod = MyParser(input_data = input_data, args=["--nest.two", "1"])
+    assert(mod.args['nest']['two'])
+    with pytest.raises(SystemExit):
+        mod = MyParser(input_data = input_data, args=["--nest.two", "notabool"])

--- a/test/test_argschema_parser.py
+++ b/test/test_argschema_parser.py
@@ -45,7 +45,27 @@ def test_my_default_nested_parser():
                                     args=None)
 
 
-def test_boolean_command_line():
+@pytest.mark.parametrize("default,args,expected", [
+    (True, ["--nest.two", "False"], False),
+    (True, ["--nest.two", "0"], False),
+    (True, ["--nest.two", "'f'"], False),
+    (False, ["--nest.two", "True"], True),
+    (False, ["--nest.two", "1"], True)
+])
+def test_boolean_command_line(default, args, expected):
+    input_data = {
+        'a':5,
+        'nest':{
+            'one':7,
+            'two':default
+        }
+    }
+    mod = MyParser(input_data=input_data, args=args)
+    assert(isinstance(mod.args['nest']['two'], bool))
+    assert(mod.args['nest']['two'] == expected)
+
+
+def test_bad_cli_input():
     input_data = {
         'a':5,
         'nest':{
@@ -53,14 +73,5 @@ def test_boolean_command_line():
             'two':True
         }
     }
-    mod = MyParser(input_data = input_data, args=["--nest.two", "False"])
-    assert(not mod.args['nest']['two'])
-    mod = MyParser(input_data = input_data, args=["--nest.two", "0"])
-    assert(not mod.args['nest']['two'])
-    input_data["nest"]["two"] = False
-    mod = MyParser(input_data = input_data, args=["--nest.two", "True"])
-    assert(mod.args['nest']['two'])
-    mod = MyParser(input_data = input_data, args=["--nest.two", "1"])
-    assert(mod.args['nest']['two'])
     with pytest.raises(SystemExit):
-        mod = MyParser(input_data = input_data, args=["--nest.two", "notabool"])
+        mod = MyParser(input_data=input_data, args=["--nest.two", "notabool"])


### PR DESCRIPTION
Resolves #64 by using ast.literal_eval to handle the argument in the parser and then letting marshmallow serialization handle the actual type casting.