### PR TITLE
allow user to provide json dump options when using ArgSchemaParser.output

### DIFF
--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -224,6 +224,9 @@ class ArgSchemaParser(object):
             output dictionary to output 
         output_path: str
             path to save to output file, optional (with default to self.mod['output_json'] location)
+        **json_dump_options :
+            will be passed through to json.dump
+         
         Raises
         ------
         marshmallow.ValidationError

--- a/argschema/argschema_parser.py
+++ b/argschema/argschema_parser.py
@@ -214,7 +214,7 @@ class ArgSchemaParser(object):
         
         return output_json
 
-    def output(self,d,output_path=None):
+    def output(self,d,output_path=None,**json_dump_options):
         """method for outputing dictionary to the output_json file path after
         validating it through the output_schema_type
 
@@ -234,7 +234,7 @@ class ArgSchemaParser(object):
         
         output_json = self.get_output_json(d)
         with open(output_path,'w') as fp:
-            json.dump(output_json,fp)
+            json.dump(output_json,fp,**json_dump_options)
 
     def load_schema_with_defaults(self  ,schema, args):
         """method for deserializing the arguments dictionary (args)

--- a/test/test_argschema_parser.py
+++ b/test/test_argschema_parser.py
@@ -1,3 +1,5 @@
+import json
+
 import argschema
 import pytest
 
@@ -75,3 +77,29 @@ def test_bad_cli_input():
     }
     with pytest.raises(SystemExit):
         mod = MyParser(input_data=input_data, args=["--nest.two", "notabool"])
+
+
+def test_parser_output(tmpdir_factory):
+
+    json_path = tmpdir_factory.mktemp('data').join('test_output.json')
+
+    input_data = {
+        'a':5,
+        'nest':{
+            'one':7,
+            'two':False
+        }
+    }
+    mod = MyParser(input_data=input_data)
+
+    mod.output(mod.args, output_path=str(json_path), indent=2)
+    with open(str(json_path), 'r') as jf:
+        obt = json.load(jf)
+        assert(obt['nest']['one'] == mod.args['nest']['one'])
+
+    with open(str(json_path), 'r') as jf:
+        lines = jf.readlines()
+        assert( len(lines) >= 8 ) # true if indent param worked
+
+
+


### PR DESCRIPTION
A simple QoL change - I like to set the indent parameter when writing json from Python in order to get readable outputs. This change lets the user pass that and other keyword args for json.dump through ArgSchemaParser.output