### PR TITLE
Appveyor tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - pip install -r test_requirements.txt
-  - pip install .
+  - pip install -r requirements.txt
 
 test_script:
   - python setup.py test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+build: false
+
+environment:
+  matrix:
+    - MINICONDA: "C:\\Miniconda-x64"
+      PYTHON: 2.7
+    - MINICONDA: "C:\\Miniconda36-x64"
+      PYTHON: 3.6
+
+install:
+  - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - pip install -r test_requirements.txt
+  - pip install .
+
+test_script:
+  - python setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --boxed --cov=argschema --cov-report html --junitxml=test-reports/test.xml
+addopts = --cov=argschema --cov-report html --junitxml=test-reports/test.xml
 
 [aliases]
 test=pytest 

--- a/test/fields/test_files.py
+++ b/test/fields/test_files.py
@@ -23,11 +23,12 @@ enoent_outfile_example = {
 
 def test_outputfile_no_write(tmpdir):
     outdir = tmpdir.mkdir('cannot_write_here')
-    outdir.chmod(0o222)
+    outdir.chmod(0o444)
     outfile = outdir.join('test')
     with pytest.raises(mm.ValidationError):
         mod = ArgSchemaParser(input_data={'output_file': str(outfile)},
                               schema_type=BasicOutputFile)
+    outdir.chmod(0o666)
 
 
 def test_outputfile_not_a_path():

--- a/test/fields/test_files.py
+++ b/test/fields/test_files.py
@@ -3,6 +3,7 @@ from argschema import ArgSchemaParser, ArgSchema
 from argschema.fields import InputFile, OutputFile, InputDir, OutputDir
 import marshmallow as mm
 import os
+import stat
 
 
 # OUTPUT FILE TESTS
@@ -71,18 +72,21 @@ class BasicOutputDir(ArgSchema):
     output_dir = OutputDir(required=True, description="basic output dir")
 
 
-def test_output_dir_basic():
+def test_output_dir_basic(tmpdir):
+    outdir = tmpdir.mkdir('mytmp')
     output_dir_example = {
-        'output_dir': '/tmp/mytmp'
+        'output_dir': str(outdir)
     }
     mod = ArgSchemaParser(schema_type=BasicOutputDir,
                           input_data=output_dir_example,
                           args=[])
 
 
-def test_output_dir_bad_permission():
+def test_output_dir_bad_permission(tmpdir):
+    outdir = tmpdir.mkdir('no_write')
+    outdir.chmod(0o222)
     output_dir_example = {
-        'output_dir': '/'
+        'output_dir': outdir
     }
     with pytest.raises(mm.ValidationError):
         mod = ArgSchemaParser(schema_type=BasicOutputDir,


### PR DESCRIPTION
Adds basic appveyor builds for 2.7 and 3.6. Incorporates some test cleanup to prevent tests hanging on Windows. Demonstrates #80 .