### PR TITLE
Marshmallow 3 api smoothing

### DIFF
--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -113,6 +113,11 @@ class OutputDir(mm.fields.Str):
         # use outputfile to test that a file in this location is a valid path
         validate_outpath(value)
 
+def validate_input_path(value):
+    if not os.path.isfile(value):
+        raise mm.ValidationError("%s is not a file" % value)
+    elif not os.access(value, os.R_OK):
+        raise mm.ValidationError("%s is not readable" % value)
 
 class InputDir(mm.fields.Str):
     """InputDir is  :class:`marshmallow.fields.Str` subclass which is a path to a
@@ -135,7 +140,4 @@ class InputFile(mm.fields.Str):
     """
 
     def _validate(self, value):
-        if not os.path.isfile(value):
-            raise mm.ValidationError("%s is not a file" % value)
-        elif not os.access(value, os.R_OK):
-            raise mm.ValidationError("%s is not readable" % value)
+        validate_input_path(value)

--- a/argschema/utils.py
+++ b/argschema/utils.py
@@ -371,11 +371,11 @@ def schema_argparser(schema):
 
     """
 
-    #build up a list of argument groups using recursive function
-    #to traverse the tree, root node gets the description given by doc string
-    #of the schema
+    # build up a list of argument groups using recursive function
+    # to traverse the tree, root node gets the description given by doc string
+    # of the schema
     arguments = build_schema_arguments(schema,description=schema.__doc__)
-    #make the root schema appeear first rather than last
+    # make the root schema appeear first rather than last
     arguments = [arguments[-1]]+arguments[0:-1]
 
     parser = argparse.ArgumentParser()
@@ -385,3 +385,64 @@ def schema_argparser(schema):
         for arg_name,arg in arg_group['args'].items():
             group.add_argument(arg_name, **arg)
     return parser
+
+def load(schema, d):
+    """ function to wrap marshmallow load to smooth 
+        differences from marshmallow 2 to 3 
+        
+    Parameters
+    ----------
+    schema: marshmallow.Schema
+        schema that you want to use to validate
+    d: dict
+        dictionary to validate and load
+    
+    Returns
+    -------
+    dict
+        deserialized and validated dictionary
+    
+    Raises
+    ------
+    marshmallow.ValidationError
+        if the dictionary does not conform to the schema
+    """
+
+    results = schema.load(d)
+    if isinstance(results, tuple):
+        (results, errors) = results
+        if len(errors) > 0:
+            raise mm.ValidationError(errors)
+
+    return results
+
+
+def dump(schema, d):
+    """ function to wrap marshmallow dump to smooth 
+        differences from marshmallow 2 to 3 
+        
+    Parameters
+    ----------
+    schema: marshmallow.Schema
+        schema that you want to use to validate and dump
+    d: dict
+        dictionary to validate and dump
+    
+    Returns
+    -------
+    dict
+        serialized and validated dictionary
+    
+    Raises
+    ------
+    marshmallow.ValidationError
+        if the dictionary does not conform to the schema
+    """
+
+    results = schema.dump(d)
+    if isinstance(results, tuple):
+        (results, errors) = results
+        if len(errors) > 0:
+            raise mm.ValidationError(errors)
+
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy
-marshmallow<=3.0.0
+marshmallow

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('test_requirements.txt','r') as f:
     test_required = f.read().splitlines()
 
 setup(name='argschema',
-      version='1.16.6',
+      version='1.17.0',
       description=' a wrapper for setting up modules that can have parameters specified by command line arguments,\
        json_files, or dictionary objects. Providing a common wrapper for data processing modules.',
       author='Forrest Collman,David Feng',

--- a/test/fields/test_numpyarray.py
+++ b/test/fields/test_numpyarray.py
@@ -1,6 +1,7 @@
 import pytest
 from argschema import ArgSchemaParser, ArgSchema
 from argschema.fields import NumpyArray
+from argschema.utils import load,dump
 import marshmallow as mm
 import numpy as np
 
@@ -46,7 +47,6 @@ def test_serialize():
     object_dict = {
         'a': np.array([1, 2])
     }
-    (json_dict, errors) = schema.dump(object_dict)
-    assert(len(errors) == 0)
+    json_dict = dump(schema, object_dict)
     assert(type(json_dict['a']) == list)
     assert(json_dict['a'] == object_dict['a'].tolist())

--- a/test/test_nested_examples.py
+++ b/test/test_nested_examples.py
@@ -18,5 +18,4 @@ def test_nested_example():
 
 def test_nested_marshmallow_example():
     schema = MySchema()
-    (result,errors)=schema.load({})
-    assert(len(errors)==0)
+    argschema.utils.load(schema, {})


### PR DESCRIPTION
I think by wrapping the load and dump calls I have effectively smoothed over the differences in the api between marshmallow 2 and 3. 