### PR TITLE
fix errno misuse for python 3.7

### DIFF
--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -95,7 +95,7 @@ class OutputDir(mm.fields.Str):
                 if self.mode is not None:
                     os.chmod(value, self.mode)
             except OSError as e:
-                if e.errno == os.errno.EEXIST:
+                if e.errno == errno.EEXIST:
                     pass
                 else:
                     raise mm.ValidationError(


### PR DESCRIPTION
os.errno exists in python <3.7, but using errno explicitly is better.