### PR TITLE
true file object for output file test

### DIFF
--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -8,8 +8,8 @@ import errno
 def validate_outpath(path):
     try:
         with tempfile.NamedTemporaryFile(mode='w', dir=path) as tfile:
-            tfile.file.write('0')
-            tfile.file.close()
+            tfile.write('0')
+            tfile.close()
 
     except Exception as e:
         if isinstance(e, OSError):

--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -8,8 +8,8 @@ import errno
 def validate_outpath(path):
     try:
         with tempfile.NamedTemporaryFile(mode='w', dir=path) as tfile:
-            tfile.write('0')
-            tfile.close()
+            tfile.file.write('0')
+            tfile.file.close()
 
     except Exception as e:
         if isinstance(e, OSError):

--- a/test/fields/test_files.py
+++ b/test/fields/test_files.py
@@ -22,7 +22,7 @@ enoent_outfile_example = {
 
 def test_outputfile_no_write(tmpdir):
     outdir = tmpdir.mkdir('cannot_write_here')
-    outdir.chmod(0o444)
+    os.chmod(outdir, os.O_RDONLY)
     outfile = outdir.join('test')
     with pytest.raises(mm.ValidationError):
         ArgSchemaParser(input_data={'output_file': str(outfile)},


### PR DESCRIPTION
I am curious if this fixes a couple of your appveyor test failures.
```
The returned object is a true file object on POSIX platforms. On other platforms, it is a file-like object whose file attribute is the underlying true file object.
```
https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile