### PR TITLE
removes setup requires pytest_runner due to pip security and ssl issues

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,7 @@ install:
   - conda update -q conda
   - pip install -r test_requirements.txt
   - pip install -r requirements.txt
+  - pip install . 
 
 test_script:
-  - python setup.py test
+  - pytest test/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             pip install -r requirements.txt
             sed '/pywin32/d' test_requirements.txt > test_requirements_nowin.txt
             pip install -r test_requirements_nowin.txt
-            pip install .
+            pip install -e .
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            python setup.py test
+            pytest test/
             bash <(curl -s https://codecov.io/bash)
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
             pip install -r requirements.txt
             sed '/pywin32/d' test_requirements.txt > test_requirements_nowin.txt
             pip install -r test_requirements_nowin.txt
+            pip install .
 
       - save_cache:
           paths:

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,4 @@ setup(name='argschema',
       packages=find_packages(),
       url='https://github.com/AllenInstitute/argschema',
       install_requires=required,
-      setup_requires=['pytest-runner'],
       tests_require=test_required)

--- a/test/test_first_test.py
+++ b/test/test_first_test.py
@@ -279,7 +279,7 @@ def test_simple_description():
         'd': [1, 5, 4]
     }
     argschema.ArgSchemaParser(
-        input_data=d, schema_type=MyShorterExtension)
+        input_data=d, schema_type=MyShorterExtension, args=[])
 
 class MySchemaPostLoad(ArgSchema):
     xid = argschema.fields.Int(required=True)


### PR DESCRIPTION
pytest_runner causes failures when pip installing due to ssl validation. pytest_runner has been deprecated because of this, and it is not used anyways.