### PR TITLE
Changed method of read validation to use the standard library function.  

### DIFF
--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -151,9 +151,11 @@ def validate_input_path(value):
     if not os.path.isfile(value):
         raise mm.ValidationError("%s is not a file" % value)
     else:
-        with open(value) as f:
-            if not f.readable():
-                raise mm.ValidationError("%s is not readable" % value)   
+        try:
+            with open(value) as f:  
+                pass
+        except Exception as value:
+            raise mm.ValidationError("%s is not readable" % value)   
 
 class InputDir(mm.fields.Str):
     """InputDir is  :class:`marshmallow.fields.Str` subclass which is a path to a

--- a/argschema/fields/files.py
+++ b/argschema/fields/files.py
@@ -151,17 +151,9 @@ def validate_input_path(value):
     if not os.path.isfile(value):
         raise mm.ValidationError("%s is not a file" % value)
     else:
-        if sys.platform == "win32":
-            try:
-                with open(value) as f:
-                    s = f.read()
-            except IOError as x:
-                if x.errno == errno.EACCES:
-                    raise mm.ValidationError("%s is not readable" % value)
-        else:
-            if not os.access(value, os.R_OK):
-                raise mm.ValidationError("%s is not readable" % value)
-
+        with open(value) as f:
+            if not f.readable():
+                raise mm.ValidationError("%s is not readable" % value)   
 
 class InputDir(mm.fields.Str):
     """InputDir is  :class:`marshmallow.fields.Str` subclass which is a path to a


### PR DESCRIPTION
validate_input_path() incurs substantial penalties because it reads the entirety of each input file to verify a file is readable.  The python file class supports the readable() callable for determining readability.