### PR TITLE
bumps marshmallow version and argschema dependency

### DIFF
--- a/argschema/__init__.py
+++ b/argschema/__init__.py
@@ -4,7 +4,7 @@ from .schemas import ArgSchema # noQA:F401
 from .argschema_parser import ArgSchemaParser # noQA:F401
 from .deprecated import JsonModule, ModuleParameters # noQA:F401
 
-__version__ = "2.0.2"
+__version__ = "3.0.0"
 
 def main():  # pragma: no cover
     jm = ArgSchemaParser()

--- a/argschema/autodoc.py
+++ b/argschema/autodoc.py
@@ -87,7 +87,7 @@ def process_schemas(app, what, name, obj, options, lines):
                         # get the set of types this field was derived from
                         if isinstance(field, mm.fields.List):
                             # if it's a list we want to do this for its container
-                            base_types = inspect.getmro(type(field.container))
+                            base_types = inspect.getmro(type(field.inner))
                         else:
                             base_types = inspect.getmro(type(field))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ description_file = README.md
 [options]
 install_requires =
   numpy
-  marshmallow>=3.12,<4.0
+  marshmallow>=3.0.0,<4.0
   pyyaml
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = argschema
-version = 1.15.3
+version = 3.0.0
 description= "a wrapper for setting up modules that can have parameters specified by command line arguments, json_files, or dictionary objects. Providing a common wrapper for data processing modules."
 authors = ['Forrest Collman, David Feng']
 author_email=forrestc@alleninstitute.org
@@ -10,7 +10,7 @@ description_file = README.md
 [options]
 install_requires =
   numpy
-  marshmallow==3.0.0rc6
+  marshmallow>=3.12,<4.0
   pyyaml
 
 [options.extras_require]


### PR DESCRIPTION
* current marshmallow version is 3.12.1. I checked locally and the tests pass at marshmallow 3.0.0
* tweaked one autodoc thing to reproduce the same docstring as before - did not investigate the marshmallow changes that necessitated this deeply.